### PR TITLE
feat: Implement edit functionality for internal users with modal and …

### DIFF
--- a/conexia_front/src/app/admin/internal-users/page.jsx
+++ b/conexia_front/src/app/admin/internal-users/page.jsx
@@ -10,11 +10,13 @@ import { Plus } from 'lucide-react';
 import CreateInternalUserModal from '@/components/admin/internal-users/CreateInternalUserModal';
 import useDeleteInternalUser from '@/hooks/internal-users/useDeleteInternalUser';
 import DeleteInternalUserModal from '@/components/admin/internal-users/DeleteInternalUserModal';
+import EditInternalUserModal from '@/components/admin/internal-users/EditInternalUserModal';
 
 export default function InternalUsersPage() {
   const internalUsers = useInternalUsers();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [userToDelete, setUserToDelete] = useState(null);
+  const [userToEdit, setUserToEdit] = useState(null);
   const { handleDelete, deletingId } = useDeleteInternalUser();
 
   return (
@@ -54,6 +56,7 @@ export default function InternalUsersPage() {
         <InternalUsersTable
           {...internalUsers}
           onDeleteUser={(user) => setUserToDelete(user)}
+          onEditUser={(user) => setUserToEdit(user)}
         />
       </main>
 
@@ -71,6 +74,14 @@ export default function InternalUsersPage() {
           onConfirm={() => handleDelete(userToDelete.id)}
           onCancel={() => setUserToDelete(null)}
           onUserDeleted={internalUsers.refetch}
+        />
+      )}
+
+      {userToEdit && (
+        <EditInternalUserModal
+          user={userToEdit}
+          onClose={() => setUserToEdit(null)}
+          onUserUpdated={internalUsers.refetch}
         />
       )}
     </>

--- a/conexia_front/src/components/admin/internal-users/EditInternalUserModal.jsx
+++ b/conexia_front/src/components/admin/internal-users/EditInternalUserModal.jsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import InputField from '@/components/form/InputField';
+import Button from '@/components/ui/Button';
+import SelectField from '@/components/form/SelectField';
+import { validatePassword } from '@/utils/validation';
+import { useInternalRoles } from '@/hooks/internal-users/useInternalRoles';
+import useUpdateInternalUser from '@/hooks/internal-users/useUpdateInternalUser';
+import { ROLES, ROLES_NAME } from '@/constants/roles';
+
+export default function EditInternalUserModal({ user, onClose, onUserUpdated }) {
+  const { roles } = useInternalRoles(); // [{ key: 1, value: 'admin' }, { key: 3, value: 'moderador' }]
+  const { handleUpdate, updatingId } = useUpdateInternalUser();
+
+  const [form, setForm] = useState({
+    password: '',
+    roleId: '',
+  });
+
+  const [initialRoleId, setInitialRoleId] = useState('');
+  const [touched, setTouched] = useState({});
+  const [showPwd, setShowPwd] = useState(false);
+  const [msg, setMsg] = useState(null);
+
+  const isAdmin = user.role === ROLES.ADMIN;
+  const isModerator = user.role === ROLES.MODERATOR;
+
+  // ✅ Setear roleId inicial cuando los roles estén cargados
+  useEffect(() => {
+    if (roles.length > 0) {
+      const roleEntry = roles.find((r) => r.value === user.role);
+      if (roleEntry) {
+        const roleIdStr = roleEntry.key.toString();
+        setForm((prev) => ({ ...prev, roleId: roleIdStr }));
+        setInitialRoleId(roleIdStr);
+      }
+    }
+  }, [roles, user.role]);
+
+  useEffect(() => {
+    if (msg?.ok) {
+      const timeout = setTimeout(() => {
+        setMsg(null);
+        onClose();
+        if (onUserUpdated) onUserUpdated();
+      }, 1500);
+      return () => clearTimeout(timeout);
+    }
+  }, [msg, onClose, onUserUpdated]);
+
+  useEffect(() => {
+    if (msg && !msg.ok) {
+      const timeout = setTimeout(() => setMsg(null), 5000);
+      return () => clearTimeout(timeout);
+    }
+  }, [msg]);
+
+  const handleChange = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    if (touched[field]) {
+      setTouched((prev) => ({ ...prev, [field]: true }));
+    }
+  };
+
+  const getError = (field) => {
+    if (!touched[field]) return '';
+
+    if (field === 'password' && form.password.trim()) {
+      return validatePassword(form.password);
+    }
+
+    if (field === 'roleId' && !form.roleId) {
+      return 'Debe seleccionar un rol.';
+    }
+
+    return '';
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    const errors = {};
+
+    if (form.password.trim()) {
+      const pwdError = validatePassword(form.password);
+      if (pwdError) errors.password = pwdError;
+    }
+
+    if (!form.roleId) {
+      errors.roleId = 'Debe seleccionar un rol.';
+    }
+
+    setTouched({
+      password: !!form.password.trim(),
+      roleId: true,
+    });
+
+    if (Object.keys(errors).length > 0) return;
+
+    const isPasswordChanged = !!form.password.trim();
+    const isRoleChanged = form.roleId.toString() !== initialRoleId.toString();
+
+    if (!isPasswordChanged && !isRoleChanged) {
+      setMsg({ ok: false, text: 'No se está haciendo ninguna actualización.' });
+      return;
+    }
+
+    const payload = {
+      ...(isPasswordChanged && { password: form.password }),
+      ...(isRoleChanged && { roleId: parseInt(form.roleId, 10) }),
+    };
+
+    try {
+      await handleUpdate(user.id, payload);
+
+      let changedFields = [];
+      if (isRoleChanged) changedFields.push('rol');
+      if (isPasswordChanged) changedFields.push('contraseña');
+
+      const fieldsText = changedFields.join(' y ');
+      const successMessage = `Usuario actualizado correctamente. Se modifico ${fieldsText}.`;
+
+      setMsg({ ok: true, text: successMessage });
+    } catch (error) {
+      const message = error.message || '';
+      let userFriendlyMessage = 'Ocurrió un error al actualizar el usuario.';
+
+      if (message.includes('not allowed to update')) {
+        userFriendlyMessage = 'No puedes modificar tu propio usuario.';
+      } else if (message.includes('New password cannot be the same')) {
+        userFriendlyMessage = 'La nueva contraseña no puede ser igual a la contraseña actual.';
+      }
+
+      setMsg({ ok: false, text: userFriendlyMessage });
+    }
+  };
+
+  // 🎯 Construir opciones según permisos
+  const adminOption = roles.find((r) => r.value === ROLES.ADMIN);
+  const modOption = roles.find((r) => r.value === ROLES.MODERATOR);
+
+  const roleOptions = isAdmin
+    ? adminOption
+      ? [{ value: adminOption.key.toString(), label: ROLES_NAME[adminOption.value] }]
+      : []
+    : [modOption, adminOption]
+        .filter(Boolean)
+        .map((r) => ({
+          value: r.key.toString(),
+          label: ROLES_NAME[r.value],
+        }));
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex justify-center items-center">
+      <div className="bg-white p-6 rounded-xl shadow-lg w-full max-w-sm">
+        <h2 className="text-xl font-bold text-center text-conexia-green mb-1">
+          Editar usuario interno
+        </h2>
+
+        <p className="text-center text-conexia-bluegreen mb-6 mt-4 text-base">
+          Estás editando a:{' '}
+          <span className="font-semibold text-conexia-green">{user.email}</span>
+        </p>
+
+        <form onSubmit={handleSubmit} noValidate className="space-y-4">
+          {/* Campo rol */}
+          <div>
+            <label className="text-sm font-semibold text-conexia-green block mb-1">
+              Rol
+            </label>
+            <SelectField
+              name="roleId"
+              value={form.roleId}
+              onChange={(e) => handleChange('roleId', e.target.value)}
+              onBlur={() => setTouched((prev) => ({ ...prev, roleId: true }))}
+              options={roleOptions}
+              error={getError('roleId')}
+              placeholder="Seleccione un rol"
+            />
+          </div>
+
+          {/* Campo contraseña */}
+          <div>
+            <label className="text-sm font-semibold text-conexia-green block mb-1">
+              Nueva contraseña (opcional)
+            </label>
+            <InputField
+              type="password"
+              placeholder="Nueva contraseña"
+              value={form.password}
+              onChange={(e) => handleChange('password', e.target.value)}
+              onBlur={() => setTouched((prev) => ({ ...prev, password: true }))}
+              error={getError('password')}
+              showToggle
+              show={showPwd}
+              onToggle={() => setShowPwd(!showPwd)}
+            />
+          </div>
+
+          {/* Mensaje final */}
+          <div className="min-h-[40px] text-center text-sm transition-all duration-300">
+            {msg && (
+              <p className={msg.ok ? 'text-green-600' : 'text-red-600'}>
+                {msg.text}
+              </p>
+            )}
+          </div>
+
+          {/* Botones */}
+          <div className="flex justify-end gap-2 mt-2">
+            <Button type="submit" variant="primary" disabled={updatingId === user.id}>
+              {updatingId === user.id ? 'Actualizando...' : 'Guardar'}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onClose}
+              disabled={updatingId === user.id}
+            >
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/conexia_front/src/components/admin/internal-users/InternalUsersTable.jsx
+++ b/conexia_front/src/components/admin/internal-users/InternalUsersTable.jsx
@@ -2,11 +2,7 @@
 
 import Pagination from '@/components/common/Pagination';
 import Button from '@/components/ui/Button';
-
-const roleLabels = {
-  admin: 'Administrador',
-  moderador: 'Moderador',
-};
+import { ROLES_NAME } from '@/constants/roles';
 
 export default function InternalUsersTable({
   users = [],
@@ -16,6 +12,7 @@ export default function InternalUsersTable({
   setFilters,
   loading,
   onDeleteUser,
+  onEditUser,
 }) {
   const showEmptyMessage = !loading && users.length === 0;
 
@@ -51,7 +48,7 @@ export default function InternalUsersTable({
                 className="border-b hover:bg-gray-50 h-[52px]" // altura fija de la fila
               >
                 <td className="p-2 truncate max-w-[300px]">{user.email}</td>
-                <td className="p-2 w-[150px] text-center">{roleLabels[user.role] || user.role}</td>
+                <td className="p-2 w-[150px] text-center">{ROLES_NAME[user.role] || user.role}</td>
                 <td className="p-2 w-[180px] text-center">
                   {new Date(user.createdAt).toLocaleDateString()}
                 </td>
@@ -59,7 +56,11 @@ export default function InternalUsersTable({
                 <td className="p-2 text-center align-middle">
                   {user.isActive ? (
                     <div className="flex justify-center gap-x-2">
-                      <Button variant="edit" className="px-3 py-1 text-xs">
+                      <Button
+                        variant="edit"
+                        className="px-3 py-1 text-xs"
+                        onClick={() => onEditUser(user)}
+                      >
                         Editar
                       </Button>
                       <Button

--- a/conexia_front/src/hooks/internal-users/useUpdateInternalUser.js
+++ b/conexia_front/src/hooks/internal-users/useUpdateInternalUser.js
@@ -1,0 +1,29 @@
+'use client';
+
+import { useState } from 'react';
+import { updateInternalUser } from '@/service/internalUser/internalUserFetch';
+
+export default function useUpdateInternalUser() {
+  const [updatingId, setUpdatingId] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleUpdate = async (id, data) => {
+    setUpdatingId(id);
+    setError(null);
+
+    try {
+      await updateInternalUser(id, data);
+    } catch (err) {
+      const message =
+        err?.response?.data?.message ||
+        err?.message ||
+        'Error al actualizar el usuario.';
+      setError(message);
+      throw new Error(message); // <- lanzamos el error para que el modal lo maneje
+    } finally {
+      setUpdatingId(null);
+    }
+  };
+
+  return { handleUpdate, updatingId, error };
+}

--- a/conexia_front/src/service/internalUser/internalUserFetch.js
+++ b/conexia_front/src/service/internalUser/internalUserFetch.js
@@ -73,3 +73,22 @@ export async function deleteInternalUser(id) {
 
   return res.json();
 }
+
+export async function updateInternalUser(id, data) {
+  const res = await fetchWithRefresh(`${config.API_URL}/internal-users/${id}`, {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || 'Error al actualizar usuario');
+    console.log(error.message);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
### CNX79 - Modificar Usuario Interno

#### Descripción

Este Pull Request implementa la funcionalidad de edición para usuarios internos dentro de la aplicación Conexia. Permite a administradores modificar el rol y/o la contraseña de un usuario interno existente desde la sección de "Usuarios Internos", siguiendo validaciones específicas para asegurar una experiencia coherente y segura.

Se incorpora un nuevo modal accesible desde la grilla de usuarios, el cual permite editar el rol del usuario (según permisos del usuario autenticado) y establecer una nueva contraseña de forma opcional. 

#### Cambios

1. **Nuevo modal de edición de usuario interno**  
   Se agrega un modal de edición reutilizable, accesible desde la grilla mediante el ícono de editar.  
   El modal incluye:
   - Campo de rol con opciones dinámicas según el rol del usuario logueado.
   - Campo opcional para establecer una nueva contraseña con toggle de visibilidad.
   - Validaciones en tiempo real.
   - Manejo de errores del backend.

2. **Validación de contraseña y campos requeridos**  
   - Si se ingresa una nueva contraseña, se valida localmente según las reglas establecidas (`validatePassword`).  
   - El rol es obligatorio y validado tanto en frontend como backend.
   - Se evita el envío de datos si no hay cambios.

3. **Feedback al usuario**  
   - Mensajes de éxito y error informan el resultado de la operación.
   - Los errores se eliminan automáticamente después de 5 segundos.
   - En caso de éxito, el modal se cierra automáticamente tras 1.5 segundos.

4. **Actualización de hooks y servicios**  
   - Nuevo hook `useUpdateInternalUser` con control de loading y errores.
   - Actualización de `internalUserFetch` para usar el endpoint correspondiente (`PATCH /internal-users/:id`).

```
