### PR TITLE
feat: Implement project postulations feature with evaluation modal and table

### DIFF
--- a/conexia_front/src/app/project/[id]/postulations/page.jsx
+++ b/conexia_front/src/app/project/[id]/postulations/page.jsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+import { NotFound } from '@/components/ui';
+import { ROLES } from '@/constants/roles';
+import ProjectPostulations from '@/components/project/postulations/ProjectPostulations';
+
+export default function ProjectPostulationsPage() {
+  const { id } = useParams();
+
+  return (
+    <ProtectedRoute
+      allowedRoles={[ROLES.USER]}
+      fallbackComponent={<NotFound />}
+    >
+      <ProjectPostulations projectId={id} />
+    </ProtectedRoute>
+  );
+}

--- a/conexia_front/src/components/project/detail/ProjectDetail.jsx
+++ b/conexia_front/src/components/project/detail/ProjectDetail.jsx
@@ -48,17 +48,6 @@ export default function ProjectDetail({ projectId }) {
 
   const isOwner = user && project && (String(user.id) === String(project.ownerId) || project.isOwner);
   
-  // Debug: Log para entender por qué no se muestra el botón
-  console.log('PostulationButton Debug:', {
-    user: user?.id,
-    projectOwnerId: project?.ownerId,
-    projectIsOwner: project?.isOwner,
-    isOwner: isOwner,
-    roleName: roleName,
-    shouldShowButton: !isOwner,
-    roleCheck: roleName === 'USER'
-  });
-  
   const skills = Array.isArray(project.skills) ? project.skills : (project.skills ? [project.skills] : []);
   const ownerName = getShortName(project.owner || ''); // owner ya viene como string del backend
   const ownerImage = project.ownerImage || null; // ownerImage ya viene como string del backend
@@ -242,14 +231,22 @@ export default function ProjectDetail({ projectId }) {
                     />
                   </>
                 )}
-                {/* Botón Eliminar proyecto en mobile */}
+                {/* Botones Ver Postulaciones y Eliminar proyecto en mobile */}
                 {isOwner && (
-                  <button
-                    className="md:hidden bg-conexia-coral text-white px-3 py-2 rounded font-semibold hover:bg-conexia-coral/90 transition text-sm"
-                    onClick={() => setShowDeleteModal(true)}
-                  >
-                    Eliminar proyecto
-                  </button>
+                  <>
+                    <button
+                      className="md:hidden bg-conexia-green text-white px-3 py-2 rounded font-semibold hover:bg-conexia-green/90 transition text-sm"
+                      onClick={() => router.push(`/project/${projectId}/postulations`)}
+                    >
+                      Ver Postulaciones
+                    </button>
+                    <button
+                      className="md:hidden bg-conexia-coral text-white px-3 py-2 rounded font-semibold hover:bg-conexia-coral/90 transition text-sm"
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Eliminar proyecto
+                    </button>
+                  </>
                 )}
               </div>
             </div>
@@ -263,12 +260,20 @@ export default function ProjectDetail({ projectId }) {
                   <button className="hidden md:block bg-blue-600 text-white px-5 py-2 rounded font-semibold hover:bg-blue-700 transition">Contactar</button>
                 )}
                 {isOwner ? (
-                  <button
-                    className="hidden md:block bg-conexia-coral text-white px-5 py-2 rounded font-semibold hover:bg-conexia-coral/90 transition"
-                    onClick={() => setShowDeleteModal(true)}
-                  >
-                    Eliminar proyecto
-                  </button>
+                  <>
+                    <button
+                      className="hidden md:block bg-conexia-green text-white px-5 py-2 rounded font-semibold hover:bg-conexia-green/90 transition"
+                      onClick={() => router.push(`/project/${projectId}/postulations`)}
+                    >
+                      Ver Postulaciones
+                    </button>
+                    <button
+                      className="hidden md:block bg-conexia-coral text-white px-5 py-2 rounded font-semibold hover:bg-conexia-coral/90 transition"
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Eliminar proyecto
+                    </button>
+                  </>
                 ) : (
                   <PostulationButton
                     projectId={projectId}

--- a/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
+++ b/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { approvePostulation } from '@/service/postulations/postulationService';
+import { config } from '@/config';
+
+export default function PostulationEvaluationModal({ postulation, onClose, onApproved }) {
+  const [isApproving, setIsApproving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const router = useRouter();
+
+  const handleApprove = async () => {
+    try {
+      setIsApproving(true);
+      setError('');
+      
+      await approvePostulation(postulation.id);
+      
+      setSuccess('Postulación aprobada correctamente');
+      
+      // Mostrar mensaje de éxito por un momento antes de cerrar
+      setTimeout(() => {
+        onApproved();
+      }, 1500);
+      
+    } catch (error) {
+      console.error('Error approving postulation:', error);
+      setError(error.message || 'Error al aprobar la postulación');
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
+  const handleViewProfile = () => {
+    router.push(`/profile/userProfile/${postulation.userId}`);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-lg max-w-md w-full p-6 max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-bold text-conexia-green">
+            Evaluar Postulación
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 text-xl"
+            disabled={isApproving}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="space-y-4 mb-6">
+          {/* Warning/Info message */}
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <div className="flex items-start">
+              <div className="flex-shrink-0">
+                <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-yellow-800">
+                  Confirmación requerida
+                </h3>
+                <p className="mt-1 text-sm text-yellow-700">
+                  Una vez aprobada, la postulación no se puede revertir. El usuario será notificado automáticamente.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Applicant info */}
+          <div className="border border-gray-200 rounded-lg p-4">
+            <h3 className="font-semibold text-gray-800 mb-3">
+              Información del postulante
+            </h3>
+            
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <span className="text-gray-600">Nombre:</span>
+                <span className="font-medium">
+                  {postulation.applicantName || 'Usuario'}
+                </span>
+              </div>
+              
+              <div className="flex justify-between">
+                <span className="text-gray-600">Estado:</span>
+                <span className="font-medium text-blue-600">
+                  {postulation.status?.name || 'Sin estado'}
+                </span>
+              </div>
+              
+              {postulation.createdAt && (
+                <div className="flex justify-between">
+                  <span className="text-gray-600">Fecha de postulación:</span>
+                  <span className="font-medium">
+                    {new Date(postulation.createdAt).toLocaleDateString('es-ES')}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Profile button */}
+            <button
+              onClick={handleViewProfile}
+              className="w-full mt-3 bg-blue-50 text-blue-700 px-4 py-2 rounded hover:bg-blue-100 transition text-sm font-medium border border-blue-200"
+              disabled={isApproving}
+            >
+              Ver perfil completo
+            </button>
+          </div>
+
+          {/* CV Section */}
+          {postulation.cvUrl && (
+            <div className="border border-gray-200 rounded-lg p-4">
+              <h3 className="font-semibold text-gray-800 mb-2">
+                Currículum Vitae
+              </h3>
+              <button
+                onClick={() => {
+                  const fullUrl = `${config.DOCUMENT_URL}${postulation.cvUrl}`;
+                  window.open(fullUrl, '_blank');
+                }}
+                className="text-blue-600 hover:text-blue-900 text-sm font-medium hover:underline"
+                disabled={isApproving}
+              >
+                Descargar CV
+              </button>
+            </div>
+          )}
+
+          {/* Messages */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+              <p className="text-red-700 text-sm">{error}</p>
+            </div>
+          )}
+
+          {success && (
+            <div className="bg-green-50 border border-green-200 rounded-lg p-3">
+              <p className="text-green-700 text-sm font-medium">{success}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 bg-gray-300 text-gray-700 px-4 py-2 rounded font-medium hover:bg-gray-400 transition"
+            disabled={isApproving}
+          >
+            Cancelar
+          </button>
+          
+          <button
+            onClick={handleApprove}
+            disabled={isApproving || success}
+            className="flex-1 bg-conexia-green text-white px-4 py-2 rounded font-medium hover:bg-conexia-green/90 transition disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isApproving ? 'Aprobando...' : 'Aprobar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
+++ b/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
@@ -127,7 +127,7 @@ export default function PostulationEvaluationModal({ postulation, onClose, onApp
                   const fullUrl = `${config.DOCUMENT_URL}${postulation.cvUrl}`;
                   window.open(fullUrl, '_blank');
                 }}
-                className="text-blue-600 hover:text-blue-900 text-sm font-medium hover:underline"
+                className="text-conexia-green hover:text-conexia-green/80 text-sm font-medium hover:underline"
                 disabled={isApproving}
               >
                 Descargar CV

--- a/conexia_front/src/components/project/postulations/PostulationsTable.jsx
+++ b/conexia_front/src/components/project/postulations/PostulationsTable.jsx
@@ -124,7 +124,7 @@ export default function PostulationsTable({ postulations, onEvaluate, isLoading 
                 {postulation.cvUrl ? (
                   <button
                     onClick={() => handleDownloadCV(postulation.cvUrl)}
-                    className="text-blue-600 hover:text-blue-900 text-sm font-medium hover:underline"
+                    className="text-conexia-green hover:text-conexia-green/80 text-sm font-medium hover:underline"
                   >
                     Descargar CV
                   </button>

--- a/conexia_front/src/components/project/postulations/PostulationsTable.jsx
+++ b/conexia_front/src/components/project/postulations/PostulationsTable.jsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { config } from '@/config';
+
+export default function PostulationsTable({ postulations, onEvaluate, isLoading }) {
+  const router = useRouter();
+
+  const handleDownloadCV = (cvUrl) => {
+    if (cvUrl) {
+      const fullUrl = `${config.DOCUMENT_URL}${cvUrl}`;
+      window.open(fullUrl, '_blank');
+    }
+  };
+
+  const formatDate = (dateString) => {
+    if (!dateString) return 'Sin fecha';
+    
+    try {
+      const date = new Date(dateString);
+      // Verificar si la fecha es válida
+      if (isNaN(date.getTime())) return 'Fecha inválida';
+      
+      return date.toLocaleDateString('es-ES', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch (error) {
+      console.error('Error formatting date:', error);
+      return 'Error en fecha';
+    }
+  };
+
+  const getStatusColor = (status) => {
+    switch (status?.code) {
+      case 'activo':
+        return 'bg-blue-100 text-blue-800';
+      case 'aceptada':
+        return 'bg-green-100 text-green-800';
+      case 'rechazada':
+        return 'bg-red-100 text-red-800';
+      case 'cancelada':
+        return 'bg-gray-100 text-gray-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-8 text-center text-conexia-green">
+        Cargando postulaciones...
+      </div>
+    );
+  }
+
+  if (postulations.length === 0) {
+    return (
+      <div className="p-8 text-center text-gray-500">
+        <p className="text-lg mb-2">No se encontraron postulaciones</p>
+        <p className="text-sm">
+          Este proyecto aún no tiene postulaciones o no hay postulaciones que coincidan con el filtro seleccionado.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      {/* Vista de escritorio */}
+      <table className="w-full hidden md:table">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Postulante
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Fecha de postulación
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Estado
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              CV
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Acciones
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {postulations.map((postulation) => (
+            <tr key={postulation.id} className="hover:bg-gray-50">
+              {/* Postulante */}
+              <td className="px-6 py-4 whitespace-nowrap">
+                <button
+                  onClick={() => router.push(`/profile/userProfile/${postulation.userId}`)}
+                  className="text-conexia-green font-medium hover:underline focus:outline-none"
+                >
+                  {postulation.applicantName || 'Usuario sin nombre'}
+                </button>
+              </td>
+
+              {/* Fecha de postulación */}
+              <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
+                {postulation.createdAt ? 
+                  formatDate(postulation.createdAt) : 
+                  'Fecha no disponible'
+                }
+              </td>
+
+              {/* Estado */}
+              <td className="px-6 py-4 whitespace-nowrap">
+                <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusColor(postulation.status)}`}>
+                  {postulation.status?.name || 'Sin estado'}
+                </span>
+              </td>
+
+              {/* CV */}
+              <td className="px-6 py-4 whitespace-nowrap">
+                {postulation.cvUrl ? (
+                  <button
+                    onClick={() => handleDownloadCV(postulation.cvUrl)}
+                    className="text-blue-600 hover:text-blue-900 text-sm font-medium hover:underline"
+                  >
+                    Descargar CV
+                  </button>
+                ) : (
+                  <span className="text-gray-400 text-sm">Sin CV</span>
+                )}
+              </td>
+
+              {/* Acciones */}
+              <td className="px-6 py-4 whitespace-nowrap">
+                {postulation.status?.code === 'activo' ? (
+                  <button
+                    onClick={() => onEvaluate(postulation)}
+                    className="bg-conexia-green text-white px-3 py-1 rounded text-sm font-medium hover:bg-conexia-green/90 transition"
+                  >
+                    Evaluar
+                  </button>
+                ) : (
+                  <span className="text-gray-400 text-sm">-</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Vista móvil */}
+      <div className="md:hidden space-y-4">
+        {postulations.map((postulation) => (
+          <div key={postulation.id} className="bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
+            {/* Header con nombre y estado */}
+            <div className="flex justify-between items-start mb-3">
+              <button
+                onClick={() => router.push(`/profile/userProfile/${postulation.userId}`)}
+                className="text-conexia-green font-medium hover:underline focus:outline-none text-left"
+              >
+                {postulation.applicantName || 'Usuario'}
+              </button>
+              <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusColor(postulation.status)}`}>
+                {postulation.status?.name || 'Sin estado'}
+              </span>
+            </div>
+
+            {/* Información adicional */}
+            <div className="space-y-2 text-sm text-gray-600 mb-3">
+              <div>
+                <span className="font-medium">Fecha:</span> {formatDate(postulation.createdAt)}
+              </div>
+            </div>
+
+            {/* Acciones */}
+            <div className="flex gap-2 justify-between items-center">
+              <div>
+                {postulation.cvUrl ? (
+                  <button
+                    onClick={() => handleDownloadCV(postulation.cvUrl)}
+                    className="text-blue-600 hover:text-blue-900 text-sm font-medium hover:underline"
+                  >
+                    Descargar CV
+                  </button>
+                ) : (
+                  <span className="text-gray-400 text-sm">Sin CV</span>
+                )}
+              </div>
+              
+              {postulation.status?.code === 'activo' && (
+                <button
+                  onClick={() => onEvaluate(postulation)}
+                  className="bg-conexia-green text-white px-3 py-1 rounded text-sm font-medium hover:bg-conexia-green/90 transition"
+                >
+                  Evaluar
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/conexia_front/src/components/project/postulations/ProjectPostulations.jsx
+++ b/conexia_front/src/components/project/postulations/ProjectPostulations.jsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/context/AuthContext';
+import Navbar from '@/components/navbar/Navbar';
+import { getPostulationsByProject, getPostulationStatuses } from '@/service/postulations/postulationService';
+import { getProfileById } from '@/service/profiles/profilesFetch';
+import { fetchProjectById } from '@/service/projects/projectsFetch';
+import PostulationsTable from './PostulationsTable';
+import PostulationEvaluationModal from './PostulationEvaluationModal';
+import Pagination from '@/components/common/Pagination';
+
+export default function ProjectPostulations({ projectId }) {
+  const { user } = useAuth();
+  const router = useRouter();
+  const [project, setProject] = useState(null);
+  const [postulations, setPostulations] = useState([]);
+  const [postulationStatuses, setPostulationStatuses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedStatus, setSelectedStatus] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pagination, setPagination] = useState(null);
+  const [showEvaluationModal, setShowEvaluationModal] = useState(false);
+  const [selectedPostulation, setSelectedPostulation] = useState(null);
+  const [loadingProfiles, setLoadingProfiles] = useState(false);
+
+  // Verificar si el usuario es dueño del proyecto
+  const isOwner = user && project && (String(user.id) === String(project.ownerId) || project.isOwner);
+
+  useEffect(() => {
+    loadInitialData();
+  }, [projectId]);
+
+  useEffect(() => {
+    if (project && isOwner) {
+      loadPostulations();
+    }
+  }, [currentPage, selectedStatus, project, isOwner]);
+
+  const loadInitialData = async () => {
+    try {
+      setLoading(true);
+      
+      // Cargar datos iniciales en paralelo
+      const [projectData, statusesData] = await Promise.all([
+        fetchProjectById(projectId),
+        getPostulationStatuses()
+      ]);
+
+      setProject(projectData);
+      setPostulationStatuses(statusesData.data || []);
+    } catch (error) {
+      console.error('Error loading initial data:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadPostulations = async () => {
+    try {
+      setLoadingProfiles(true);
+      
+      const statusId = selectedStatus ? parseInt(selectedStatus) : null;
+      const response = await getPostulationsByProject(projectId, currentPage, statusId);
+      
+      if (response.success) {
+        const postulationsWithProfiles = await Promise.all(
+          response.data.postulations.map(async (postulation) => {
+            try {
+              const profileResponse = await getProfileById(postulation.userId);
+              
+              // Los datos del perfil están en profileResponse.data.profile
+              let applicantName = `Usuario ${postulation.userId}`; // Fallback con ID
+              const profileData = profileResponse.data || {};
+              const profile = profileData.profile || {};
+              
+              // Obtener primer nombre y primer apellido como en los proyectos
+              if (profile.name && profile.lastName) {
+                const firstName = profile.name.trim().split(' ')[0] || '';
+                const firstLastName = profile.lastName.trim().split(' ')[0] || '';
+                applicantName = `${firstName} ${firstLastName}`.trim();
+              } else if (profile.name) {
+                // Si solo hay name, usar la función original
+                applicantName = getShortName(profile.name);
+              } else if (profile.firstName && profile.lastName) {
+                applicantName = `${profile.firstName} ${profile.lastName}`;
+              } else if (profile.firstName) {
+                applicantName = profile.firstName;
+              } else if (profile.email) {
+                // Como último recurso, usar la primera parte del email
+                applicantName = profile.email.split('@')[0];
+              }
+              
+              return {
+                ...postulation,
+                applicantName: applicantName,
+                applicantProfile: profile
+              };
+            } catch (error) {
+              console.error(`Error loading profile for user ${postulation.userId}:`, error);
+              return {
+                ...postulation,
+                applicantName: `Usuario ${postulation.userId}`,
+                applicantProfile: {}
+              };
+            }
+          })
+        );
+
+        setPostulations(postulationsWithProfiles);
+        setPagination(response.data.pagination);
+      }
+    } catch (error) {
+      console.error('Error loading postulations:', error);
+      setPostulations([]);
+    } finally {
+      setLoadingProfiles(false);
+    }
+  };
+
+  const getShortName = (fullName) => {
+    if (!fullName || typeof fullName !== 'string') {
+      return 'Usuario';
+    }
+    
+    const names = fullName.trim().split(' ').filter(name => name.length > 0);
+    
+    if (names.length === 0) return 'Usuario';
+    if (names.length === 1) return names[0];
+    if (names.length === 2) return `${names[0]} ${names[1]}`;
+    
+    // Para 3 o más nombres, asumimos: Primer_Nombre [Segundo_Nombre] Primer_Apellido [Segundo_Apellido]
+    if (names.length >= 3) {
+      return `${names[0]} ${names[2]}`;
+    }
+    
+    return `${names[0]} ${names[1]}`;
+  };
+
+  const handleEvaluatePostulation = (postulation) => {
+    setSelectedPostulation(postulation);
+    setShowEvaluationModal(true);
+  };
+
+  const handlePostulationApproved = () => {
+    setShowEvaluationModal(false);
+    setSelectedPostulation(null);
+    // Recargar postulaciones para ver los cambios
+    loadPostulations();
+  };
+
+  const handleStatusChange = (statusId) => {
+    setSelectedStatus(statusId);
+    setCurrentPage(1); // Reset to first page when changing filter
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-conexia-green">Cargando...</div>
+      </div>
+    );
+  }
+
+  if (!project) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-red-500">Proyecto no encontrado</div>
+      </div>
+    );
+  }
+
+  if (!isOwner) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-red-500">No tienes permisos para ver las postulaciones de este proyecto</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Navbar />
+      <div className="min-h-[calc(100vh-64px)] bg-[#f3f9f8] py-8 px-6 md:px-6 pb-20 md:pb-8 flex flex-col items-center">
+        <div className="w-full max-w-7xl flex flex-col gap-6">
+          {/* Header */}
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between mb-4">
+            <h1 className="text-2xl md:text-3xl font-bold text-conexia-green mb-4 md:mb-0">
+              Postulaciones
+            </h1>
+            
+            {/* Filtro por estado */}
+            <div className="flex items-center gap-2">
+              <label className="text-sm font-medium text-gray-700">Filtrar por estado:</label>
+              <select
+                value={selectedStatus}
+                onChange={(e) => handleStatusChange(e.target.value)}
+                className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-conexia-green"
+              >
+                <option value="">Todos los estados</option>
+                {postulationStatuses.map((status) => (
+                  <option key={status.id} value={status.id}>
+                    {status.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Project info */}
+          <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
+            <h2 className="text-lg font-semibold text-conexia-green mb-2">
+              {project.title}
+            </h2>
+            <p className="text-gray-600 text-sm">
+              {project.description && project.description.length > 150
+                ? `${project.description.substring(0, 150)}...`
+                : project.description || 'Sin descripción'
+              }
+            </p>
+          </div>
+
+          {/* Tabla de postulaciones */}
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+            {loadingProfiles ? (
+              <div className="p-8 text-center text-conexia-green">
+                Cargando postulaciones...
+              </div>
+            ) : (
+              <PostulationsTable
+                postulations={postulations}
+                onEvaluate={handleEvaluatePostulation}
+                isLoading={loadingProfiles}
+              />
+            )}
+          </div>
+
+          {/* Paginación */}
+          {pagination && pagination.totalPages > 1 && (
+            <div className="flex justify-center mt-6">
+              <Pagination
+                page={currentPage}
+                hasPreviousPage={pagination.hasPreviousPage}
+                hasNextPage={pagination.hasNextPage}
+                onPageChange={setCurrentPage}
+              />
+            </div>
+          )}
+
+          {/* Botón Atrás */}
+          <div className="flex justify-start mt-6">
+            <button 
+              className="bg-red-500 text-white px-4 py-2 rounded font-semibold hover:bg-red-600 transition text-sm"
+              onClick={() => router.push(`/project/${projectId}`)}
+            >
+              ← Atrás
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Modal de evaluación */}
+      {showEvaluationModal && selectedPostulation && (
+        <PostulationEvaluationModal
+          postulation={selectedPostulation}
+          onClose={() => setShowEvaluationModal(false)}
+          onApproved={handlePostulationApproved}
+        />
+      )}
+    </>
+  );
+}

--- a/conexia_front/src/components/project/postulations/index.js
+++ b/conexia_front/src/components/project/postulations/index.js
@@ -1,0 +1,3 @@
+export { default as ProjectPostulations } from './ProjectPostulations';
+export { default as PostulationsTable } from './PostulationsTable';
+export { default as PostulationEvaluationModal } from './PostulationEvaluationModal';

--- a/conexia_front/src/service/postulations/postulationService.js
+++ b/conexia_front/src/service/postulations/postulationService.js
@@ -35,3 +35,59 @@ export const cancelPostulation = async (projectId) => {
 
   return res.json();
 };
+
+// Aprobar postulación
+export const approvePostulation = async (postulationId) => {
+  const res = await fetchWithRefresh(`${config.API_URL}/postulations/approve`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify({ postulationId }),
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || 'Error al aprobar postulación');
+  }
+
+  return res.json();
+};
+
+// Obtener postulaciones de un proyecto
+export const getPostulationsByProject = async (projectId, page = 1, statusId = null) => {
+  let url = `${config.API_URL}/postulations/project/${projectId}?page=${page}`;
+  if (statusId) {
+    url += `&statusId=${statusId}`;
+  }
+
+  const res = await fetchWithRefresh(url, {
+    method: 'GET',
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || 'Error al obtener postulaciones');
+  }
+
+  return res.json();
+};
+
+// Obtener estados de postulaciones
+export const getPostulationStatuses = async () => {
+  const res = await fetch(`${config.API_URL}/postulations/statuses`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    const error = await res.json();
+    throw new Error(error.message || 'Error al obtener estados de postulaciones');
+  }
+
+  return res.json();
+};


### PR DESCRIPTION
This pull request introduces a new "Ver Postulaciones" (View Postulations) feature for project owners, allowing them to view and evaluate user postulations for their projects. It adds a dedicated page for postulations, new UI components for listing and evaluating postulations, and integrates these into the project detail view. Debug code is also removed for cleaner production output.

**New postulations management feature:**

* Added a new page at `/project/[id]/postulations` that is accessible only to users with the `USER` role, using the `ProtectedRoute` component for access control. This page displays postulations for a specific project. ([conexia_front/src/app/project/[id]/postulations/page.jsxR1-R20](diffhunk://#diff-4d138583cff9ab0a2908f4afd069c9718094fb6aa280a562726ea8684c0cc4c0R1-R20))
* Created `PostulationsTable` component to display a list of postulations with applicant info, status, CV download links, and evaluation actions, supporting both desktop and mobile views.
* Added `PostulationEvaluationModal` component, allowing project owners to review applicant details, download CVs, and approve postulations with confirmation and success/error feedback.

**Integration into project detail view:**

* Added "Ver Postulaciones" buttons (both mobile and desktop) to the `ProjectDetail` component, visible only to the project owner, which navigate to the new postulations page. [[1]](diffhunk://#diff-c5339edab0db34ba9e4124f88b75e427cda0afc877be118ca35e3eb8f9219720L245-R249) [[2]](diffhunk://#diff-c5339edab0db34ba9e4124f88b75e427cda0afc877be118ca35e3eb8f9219720R263-R276)

**Code cleanup:**

* Removed debug logging from the `ProjectDetail` component to clean up console output.