### PR TITLE
Fix feedback toast

### DIFF
--- a/conexia_front/src/app/admin/internal-users/page.jsx
+++ b/conexia_front/src/app/admin/internal-users/page.jsx
@@ -11,6 +11,7 @@ import CreateInternalUserModal from '@/components/admin/internal-users/CreateInt
 import useDeleteInternalUser from '@/hooks/internal-users/useDeleteInternalUser';
 import DeleteInternalUserModal from '@/components/admin/internal-users/DeleteInternalUserModal';
 import EditInternalUserModal from '@/components/admin/internal-users/EditInternalUserModal';
+import Toast from '@/components/ui/Toast';
 
 function InternalUsersContent() {
   const internalUsers = useInternalUsers();
@@ -19,9 +20,16 @@ function InternalUsersContent() {
   const [userToEdit, setUserToEdit] = useState(null);
   const { handleDelete, deletingId } = useDeleteInternalUser();
 
+  // Toast state
+  const [toast, setToast] = useState({ isVisible: false, type: 'info', message: '' });
+
+  const showToast = (type, message) => {
+    setToast({ isVisible: true, type, message });
+  };
+
   return (
     <>
-      <NavbarAdmin />
+  <NavbarAdmin />
 
       <main className="bg-[#eaf5f2] min-h-screen p-8 space-y-6 max-w-7xl mx-auto pb-24">
         <div className="bg-white px-6 py-4 rounded-xl shadow-sm relative">
@@ -63,7 +71,11 @@ function InternalUsersContent() {
       {isModalOpen && (
         <CreateInternalUserModal
           onClose={() => setIsModalOpen(false)}
-          onUserCreated={internalUsers.refetch}
+          onUserCreated={() => {
+            internalUsers.refetch();
+            showToast('success', 'Usuario interno creado correctamente.');
+          }}
+          onError={(msg) => showToast('error', msg || 'Error al crear usuario interno.')}
         />
       )}
 
@@ -73,7 +85,11 @@ function InternalUsersContent() {
           loading={deletingId === userToDelete.id}
           onConfirm={() => handleDelete(userToDelete.id)}
           onCancel={() => setUserToDelete(null)}
-          onUserDeleted={internalUsers.refetch}
+          onUserDeleted={() => {
+            internalUsers.refetch();
+            showToast('success', 'Usuario interno eliminado.');
+          }}
+          onError={(msg) => showToast('error', msg || 'Error al eliminar usuario interno.')}
         />
       )}
 
@@ -81,9 +97,21 @@ function InternalUsersContent() {
         <EditInternalUserModal
           user={userToEdit}
           onClose={() => setUserToEdit(null)}
-          onUserUpdated={internalUsers.refetch}
+          onUserUpdated={() => {
+            internalUsers.refetch();
+            showToast('success', 'Usuario interno actualizado.');
+          }}
+          onError={(msg) => showToast('error', msg || 'Error al actualizar usuario interno.')}
         />
       )}
+
+      <Toast
+        position="top-center"
+        type={toast.type}
+        message={toast.message}
+        isVisible={toast.isVisible}
+        onClose={() => setToast((t) => ({ ...t, isVisible: false }))}
+      />
     </>
   );
 }

--- a/conexia_front/src/components/activity/ActivityFeed.jsx
+++ b/conexia_front/src/components/activity/ActivityFeed.jsx
@@ -1,14 +1,16 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { MdBarChart } from 'react-icons/md';
 import PublicationCard from './PublicationCard';
 import Button from '@/components/ui/Button';
 import PropTypes from 'prop-types';
 import { useRouter } from 'next/navigation';
 import { closeAllPublicationCommentsExcept } from '@/utils/publicationUtils';
+import Toast from '@/components/ui/Toast';
 
 export default function ActivityFeed({ publications, isOwner, userId }) {
   const router = useRouter();
   const visiblePublications = publications.slice(0, 2);
+  const [toast, setToast] = useState(null);
   
   // Cuando este componente se monte, asegurémonos de que todas las publicaciones estén cerradas
   useEffect(() => {
@@ -34,7 +36,12 @@ export default function ActivityFeed({ publications, isOwner, userId }) {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
             {visiblePublications.map(pub => (
-              <PublicationCard key={pub.id} publication={pub} isGridItem={true} />
+              <PublicationCard
+                key={pub.id}
+                publication={pub}
+                isGridItem={true}
+                onShowToast={(t)=> setToast(t)}
+              />
             ))}
           </div>
         )}
@@ -51,6 +58,16 @@ export default function ActivityFeed({ publications, isOwner, userId }) {
             <span className="w-full text-center">Ver más…</span>
           </a>
         </div>
+        {toast && (
+          <Toast
+            type={toast.type}
+            message={toast.message}
+            isVisible={toast.isVisible}
+            onClose={() => setToast(null)}
+            position="top-center"
+            duration={4000}
+          />
+        )}
       </div>
     </section>
   );

--- a/conexia_front/src/components/activity/EditPublicationModal.jsx
+++ b/conexia_front/src/components/activity/EditPublicationModal.jsx
@@ -365,16 +365,23 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
                           );
                         })}
                       </div>
-                      {fileError && <div className="text-red-500 text-xs mt-1">{fileError}</div>}
+                      {/* fileError moved to static area above legend */}
                     </div>
                   </div>
                 </div>
                 {/* Controls + legend */}
-                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin: 0 }}>
-                  <div className="px-4 pt-2 pb-1">
-                    <div className="text-[11px] text-conexia-green/60 leading-snug">{FILES_LEGEND}</div>
+                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl relative" style={{ margin: 0 }}>
+                  <div className="px-4 pt-2">
+                    <div className="min-h-[26px] flex items-center justify-center" aria-live="polite" aria-atomic="true">
+                      {fileError && (
+                        <div className="bg-red-50 border border-red-200 text-red-600 text-[11px] px-3 py-1 rounded-md text-center shadow-sm w-full" role="alert">
+                          {fileError}
+                        </div>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-conexia-green/60 leading-snug mt-1">{FILES_LEGEND}</div>
                   </div>
-                  <div className="h-px bg-[#e0f0f0] mx-3" />
+                  <div className="h-px bg-[#e0f0f0] mx-3 mt-2" />
                   <div className="flex items-center gap-3 px-3 pt-2 pb-2">
                     <div className="relative">
                       <button

--- a/conexia_front/src/components/activity/EditPublicationModal.jsx
+++ b/conexia_front/src/components/activity/EditPublicationModal.jsx
@@ -1,30 +1,21 @@
 import PropTypes from 'prop-types';
 import Button from '@/components/ui/Button';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { FaGlobeAmericas, FaUsers } from 'react-icons/fa';
 import { BsEmojiSmile } from 'react-icons/bs';
 import Image from 'next/image';
+import MediaPreview from '@/components/ui/MediaPreview';
+import { config } from '@/config';
+import { buildMediaUrl } from '@/utils/mediaUrl';
+
 const Picker = dynamic(() => import('emoji-picker-react'), { ssr: false });
 const MAX_DESCRIPTION = 500;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'video/mp4'];
 const MAX_FILES = 5;
 const FILES_LEGEND = 'Hasta 5 archivos. Formatos permitidos: JPG, PNG, GIF, MP4. Máx. 1 video por publicación.';
 
-// Modal de éxito tipo toast (idéntico al de crear publicación)
-function SuccessModal({ open }) {
-  if (!open) return null;
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/20">
-      <div className="bg-white border border-[#c6e3e4] rounded-2xl shadow-2xl flex flex-col items-center px-8 py-8 animate-fadeIn">
-        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-conexia-green/10 mb-4">
-          <svg width="40" height="40" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="12" fill="#e0f0f0"/><path d="M7 13.5l3 3 7-7" stroke="#1e6e5c" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
-        </div>
-        <div className="text-conexia-green text-lg font-semibold mb-2">Publicación actualizada con éxito</div>
-      </div>
-    </div>
-  );
-}
+// buildMediaUrl ahora centralizado en utils/mediaUrl
 
 function VisibilityModal({ open, onClose, value, onChange }) {
   if (!open) return null;
@@ -99,16 +90,19 @@ function VisibilityModal({ open, onClose, value, onChange }) {
 
 export default function EditPublicationModal({ open, onClose, onEdit, loading, initialDescription, initialMediaUrl, initialMediaType, initialPrivacy = 'public', user }) {
   const [description, setDescription] = useState(initialDescription || '');
-  const [files, setFiles] = useState([]); // array de archivos
+  const [files, setFiles] = useState([]); // nuevos archivos añadidos
   const [fileError, setFileError] = useState('');
   const [visibility, setVisibility] = useState(initialPrivacy === 'onlyFriends' ? 'contacts' : 'all');
   const [showVisibilityModal, setShowVisibilityModal] = useState(false);
   const [showEmoji, setShowEmoji] = useState(false);
   const [removeOriginalMedia, setRemoveOriginalMedia] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
   const fileInputRef = useRef();
   const textareaRef = useRef();
-  const [file, setFile] = useState(null); // Added useState for file and setFile
+  const [originalMediaObj, setOriginalMediaObj] = useState(initialMediaUrl ? { url: buildMediaUrl(initialMediaUrl), type: initialMediaType } : null);
+
+  // Viewer state (combines original media + new files)
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(0);
 
   // Para textarea dinámico
   const MIN_TEXTAREA_HEIGHT = 38;
@@ -126,14 +120,15 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
 
   useEffect(() => {
     setDescription(initialDescription || '');
-    setFile(null);
     setFileError('');
     setVisibility(initialPrivacy === 'onlyFriends' ? 'contacts' : 'all');
     setShowEmoji(false);
     setRemoveOriginalMedia(false);
     if (fileInputRef.current) fileInputRef.current.value = '';
+    setFiles([]);
+  setOriginalMediaObj(initialMediaUrl ? { url: buildMediaUrl(initialMediaUrl), type: initialMediaType } : null);
     setTimeout(() => adjustTextareaHeight(), 0);
-  }, [initialDescription, initialMediaUrl, initialPrivacy, open]);
+  }, [initialDescription, initialMediaUrl, initialMediaType, initialPrivacy, open]);
 
   const handleFileIconClick = (type) => {
     if (fileInputRef.current) {
@@ -149,20 +144,18 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
 
   const handleFileChange = (e) => {
     const selected = Array.from(e.target.files);
-    if (selected.length + files.length > MAX_FILES) {
+    if (selected.length + files.length + (originalMediaObj && !removeOriginalMedia ? 1 : 0) > MAX_FILES) {
       setFileError(`Máximo ${MAX_FILES} archivos por publicación.`);
       return;
     }
-    // Validar tipos y JFIF
     let error = '';
-    let videoCount = files.filter(f => f.type === 'video/mp4').length;
+    let videoCount = files.filter(f => f.type === 'video/mp4').length + ((originalMediaObj && originalMediaObj.type === 'video' && !removeOriginalMedia) ? 1 : 0);
     const newFiles = [];
     for (const f of selected) {
       if (!ALLOWED_TYPES.includes(f.type)) {
         error = 'Solo se permiten imágenes JPG, PNG, GIF o videos MP4.';
         break;
       }
-      // Bloquear JFIF
       if (f.type === 'image/jpeg') {
         const reader = new FileReader();
         reader.onload = (ev) => {
@@ -185,11 +178,18 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
       return;
     }
     setFileError('');
-    setFiles([...files, ...newFiles]);
+    setFiles(prev => [...prev, ...newFiles]);
   };
 
   const handleRemoveFile = (idx) => {
-    setFiles(files.filter((_, i) => i !== idx));
+    // If removing the original media (represented separately)
+    if (idx === 0 && originalMediaObj && !removeOriginalMedia) {
+      setRemoveOriginalMedia(true);
+      return;
+    }
+    // Adjust index if original media exists at position 0
+    const adjustedIdx = originalMediaObj && !removeOriginalMedia ? idx - 1 : idx;
+    setFiles(prev => prev.filter((_, i) => i !== adjustedIdx));
     setFileError('');
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
@@ -208,32 +208,40 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
     }, 0);
   };
 
-  // Nuevo: mostrar modal de éxito y cerrar tras editar
   const handleSave = async () => {
-    let privacy = 'public';
-    if (visibility === 'contacts') privacy = 'onlyFriends';
-    const send = {
-      description: description,
-      privacy: privacy,
-      files: files
-    };
-    if (removeOriginalMedia) {
-      send.removeMedia = true;
-    }
-    // Si onEdit es async, esperar a que termine
-    const result = onEdit(send);
-    if (result && typeof result.then === 'function') {
-      await result;
-    }
-    setRemoveOriginalMedia(false);
-    setShowSuccess(true);
-    setTimeout(() => {
-      setShowSuccess(false);
+    let privacy = visibility === 'contacts' ? 'onlyFriends' : 'public';
+    const payload = { description, privacy, files };
+    if (removeOriginalMedia) payload.removeMedia = true;
+    try {
+      const maybePromise = onEdit(payload);
+      if (maybePromise && typeof maybePromise.then === 'function') {
+        await maybePromise;
+      }
       onClose();
-    }, 1500);
+      // parent should show toast from callback resolution
+    } catch (err) {
+      // Provide error back to parent through optional error callback style
+      console.error('Edit publication failed', err);
+      onClose();
+    }
   };
 
-  if (!open && !showSuccess) return null;
+  if (!open) return null;
+
+  // Build combined media list for viewer (original first if present & not removed)
+  const combinedMedia = [];
+  if (originalMediaObj && !removeOriginalMedia) {
+    combinedMedia.push({ kind: 'original', ...originalMediaObj });
+  }
+  files.forEach(f => combinedMedia.push({ kind: 'new', file: f }));
+
+  const openViewerAt = useCallback((idx) => {
+    setViewerIndex(idx);
+    setViewerOpen(true);
+  }, []);
+  const closeViewer = () => setViewerOpen(false);
+  const nextViewer = () => setViewerIndex(i => (i + 1) % combinedMedia.length);
+  const prevViewer = () => setViewerIndex(i => (i - 1 + combinedMedia.length) % combinedMedia.length);
 
   return (
     <>
@@ -247,7 +255,7 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
             setShowVisibilityModal(false);
           }}
         />
-        <div className="relative w-full max-w-2xl mx-2 bg-white rounded-2xl shadow-2xl border border-[#c6e3e4] animate-fadeIn flex flex-col" style={{ minHeight: 420, maxHeight: 600, height: 480 }}>
+  <div className="relative w-full max-w-2xl mx-2 bg-white rounded-2xl shadow-2xl border border-[#c6e3e4] animate-fadeIn flex flex-col" style={{ minHeight: 420, maxHeight: 600, height: 480 }}>
           {/* Header */}
           <div className="p-4 border-b border-[#e0f0f0] bg-[#eef6f6] rounded-t-2xl">
             <div className="flex items-center gap-3 relative">
@@ -282,16 +290,16 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
               </button>
             </div>
           </div>
-          {/* Body (scrollable, LinkedIn style) */}
-          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4">
+          {/* Body (scrollable, unified with create modal) */}
+          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4 overflow-x-hidden">
             <div className="w-full max-w-xl flex flex-col items-center justify-center">
               <div className="flex flex-col w-full" style={{ alignItems: 'center' }}>
                 <div
-                  className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-scroll w-full"
+                  className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-auto overflow-x-hidden w-full"
                   style={{
                     minHeight: 160,
-                    maxHeight: 280,
-                    height: 280,
+                    maxHeight: 320,
+                    height: 320,
                     margin: 0,
                     borderBottom: 'none',
                   }}
@@ -316,135 +324,100 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
                       }}
                       rows={1}
                     />
-                    {/* Preview archivos SIEMPRE debajo del textarea, dentro del mismo bloque scrolleable */}
-                    {file && file.type.startsWith('image/') && file.type !== 'image/gif' && (
-                      <div className="relative w-full flex justify-center items-center mt-2 mb-2">
-                        <div className="relative w-full flex justify-center" style={{ maxWidth: '480px' }}>
-                          <img src={URL.createObjectURL(file)} alt="preview" className="max-h-56 w-full object-contain mx-auto" />
-                          <button
-                            type="button"
-                            onClick={handleRemoveFile}
-                            className="absolute top-1 right-1 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow"
-                            style={{ lineHeight: 1, pointerEvents: 'auto' }}
-                          >
-                            <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-                          </button>
-                        </div>
+                    {/* Combined media previews (original + new) */}
+                    <div className="px-2">
+                      <div className="grid grid-cols-2 gap-3">
+                        {combinedMedia.map((item, idx) => {
+                          if (item.kind === 'original') {
+                            return (
+                              <div key={`orig`} className="relative group aspect-square w-full bg-[#eef6f6] border border-[#c6e3e4] rounded-xl flex items-center justify-center overflow-hidden cursor-pointer" onClick={() => openViewerAt(idx)}>
+                                {item.type === 'image' || item.type === 'gif' ? (
+                                  <img src={item.url} alt="original" className="object-cover w-full h-full" />
+                                ) : item.type === 'video' ? (
+                                  <video src={item.url} className="object-cover w-full h-full" />
+                                ) : null}
+                                <button
+                                  type="button"
+                                  onClick={(e) => { e.stopPropagation(); handleRemoveFile(idx); }}
+                                  className="absolute top-1 right-1 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow opacity-0 group-hover:opacity-100 transition"
+                                >
+                                  <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+                                </button>
+                              </div>
+                            );
+                          }
+                          const f = item.file;
+                          return (
+                            <div key={idx} className="relative group aspect-square w-full bg-[#eef6f6] border border-[#c6e3e4] rounded-xl flex items-center justify-center overflow-hidden cursor-pointer" onClick={() => openViewerAt(idx)}>
+                              {f.type.startsWith('image/') ? (
+                                <img src={URL.createObjectURL(f)} alt={`preview-${idx}`} className="object-cover w-full h-full" />
+                              ) : f.type.startsWith('video/') ? (
+                                <video src={URL.createObjectURL(f)} className="object-cover w-full h-full" />
+                              ) : null}
+                              <button
+                                type="button"
+                                onClick={(e) => { e.stopPropagation(); handleRemoveFile(idx); }}
+                                className="absolute top-1 right-1 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow opacity-0 group-hover:opacity-100 transition"
+                              >
+                                <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+                              </button>
+                            </div>
+                          );
+                        })}
                       </div>
-                    )}
-                    {file && file.type === 'video/mp4' && (
-                      <div className="relative w-full flex justify-center items-center mt-2 mb-2">
-                        <video src={URL.createObjectURL(file)} controls className="max-h-40 w-full max-w-[260px] object-contain mx-auto" style={{ border: 'none', borderRadius: 0, background: 'none', boxShadow: 'none', margin: 0, padding: 0, display: 'block' }} />
-                        <button
-                          type="button"
-                          onClick={handleRemoveFile}
-                          className="absolute top-2 right-2 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow"
-                          style={{ lineHeight: 1, pointerEvents: 'auto' }}>
-                          <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-                        </button>
-                      </div>
-                    )}
-                    {file && file.type === 'image/gif' && (
-                      <div className="relative w-full flex justify-center items-center mt-2 mb-2">
-                        <img src={URL.createObjectURL(file)} alt="preview" className="max-h-40 w-full max-w-[260px] object-contain mx-auto" />
-                        <button
-                          type="button"
-                          onClick={handleRemoveFile}
-                          className="absolute top-2 right-2 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow"
-                          style={{ lineHeight: 1, pointerEvents: 'auto' }}>
-                          <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-                        </button>
-                      </div>
-                    )}
-                    {/* Preview original si no hay file */}
-                    {!file && initialMediaUrl && !removeOriginalMedia && (
-                      <div className="relative w-full flex justify-center items-center mt-2 mb-2">
-                        {initialMediaType === 'image' || initialMediaType === 'gif' ? (
-                          <img src={initialMediaUrl} alt="media" className="max-h-40 w-full max-w-[260px] object-contain mx-auto" />
-                        ) : initialMediaType === 'video' ? (
-                          <video src={initialMediaUrl} controls className="max-h-40 w-full max-w-[260px] object-contain mx-auto" />
-                        ) : null}
-                        <button
-                          type="button"
-                          onClick={handleRemoveFile}
-                          className="absolute top-2 right-2 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow"
-                          style={{ lineHeight: 1, pointerEvents: 'auto' }}>
-                          <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-                        </button>
-                      </div>
-                    )}
+                      {fileError && <div className="text-red-500 text-xs mt-1">{fileError}</div>}
+                    </div>
                   </div>
                 </div>
-                {/* Controles de adjuntos pegados abajo del input, sin separación */}
-                <div className="flex items-center gap-3 px-3 py-2 border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl w-full" style={{ margin: 0 }}>
-                  <button
-                    type="button"
-                    className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
-                    onClick={() => setShowEmoji((v) => !v)}
-                    title="Emoji"
-                  >
-                    <BsEmojiSmile />
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><circle cx="8" cy="10" r="2" fill="#1e6e5c"/><path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/></svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><polygon points="10,9 16,12 10,15" fill="#1e6e5c"/></svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text></svg>
-                  </button>
-                  <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
+                {/* Controls + legend */}
+                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin: 0 }}>
+                  <div className="px-4 pt-2 pb-1">
+                    <div className="text-[11px] text-conexia-green/60 leading-snug">{FILES_LEGEND}</div>
+                  </div>
+                  <div className="h-px bg-[#e0f0f0] mx-3" />
+                  <div className="flex items-center gap-3 px-3 pt-2 pb-2">
+                    <div className="relative">
+                      <button
+                        type="button"
+                        className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
+                        onClick={() => setShowEmoji((v) => !v)}
+                        title="Emoji"
+                      >
+                        <BsEmojiSmile />
+                      </button>
+                      {showEmoji && (
+                        <div className="absolute bottom-full mb-2 left-0 z-50">
+                          <div className="relative bg-white rounded-xl shadow-xl border border-[#c6e3e4] overflow-hidden" style={{ width:260, height:260 }}>
+                            <Picker
+                              onEmojiClick={(emojiData) => { handleEmojiClick(emojiData); setShowEmoji(false); }}
+                              theme="light"
+                              height={260}
+                              width={260}
+                              searchDisabled={false}
+                              emojiStyle="native"
+                              lazyLoadEmojis={true}
+                              skinTonesDisabled={false}
+                              previewConfig={{ showPreview: false }}
+                            />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                    <button type="button" onClick={() => handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><circle cx="8" cy="10" r="2" fill="#1e6e5c"/><path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/></svg>
+                    </button>
+                    <button type="button" onClick={() => handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><polygon points="10,9 16,12 10,15" fill="#1e6e5c"/></svg>
+                    </button>
+                    <button type="button" onClick={() => handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text></svg>
+                    </button>
+                    <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
+                  </div>
                 </div>
                 <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} multiple />
-                {/* Leyenda de archivos */}
-                <div className="text-xs text-conexia-green/60 mt-1 mb-1">{FILES_LEGEND}</div>
-                {fileError && <div className="text-red-500 text-xs">{fileError}</div>}
-                {/* Previews de archivos */}
-                <div className="flex flex-wrap gap-2 mt-2">
-                  {files.map((f, idx) => (
-                    <div key={idx} className="relative flex flex-col items-center">
-                      {f.type.startsWith('image/') && f.type !== 'image/gif' && (
-                        <img src={URL.createObjectURL(f)} alt="preview" className="max-h-24 w-auto object-contain rounded" />
-                      )}
-                      {f.type === 'video/mp4' && (
-                        <video src={URL.createObjectURL(f)} controls className="max-h-20 w-auto object-contain rounded" />
-                      )}
-                      {f.type === 'image/gif' && (
-                        <img src={URL.createObjectURL(f)} alt="preview" className="max-h-20 w-auto object-contain rounded" />
-                      )}
-                      <button type="button" onClick={() => handleRemoveFile(idx)} className="absolute -top-2 -right-2 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow">
-                        <svg width="16" height="16" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
-                      </button>
-                    </div>
-                  ))}
-                </div>
-                {showEmoji && (
-                  <div className="absolute bottom-20 left-6 z-50">
-                    {/* Overlay para cerrar el picker al hacer click fuera */}
-                    <div
-                      className="fixed inset-0 z-40"
-                      style={{ background: 'transparent' }}
-                      onClick={() => setShowEmoji(false)}
-                    />
-                    <div className="relative z-50 bg-white rounded-xl shadow-xl overflow-hidden" style={{ width: 260, height: 260 }}>
-                      <Picker
-                        onEmojiClick={(emojiData) => {
-                          handleEmojiClick(emojiData);
-                          setShowEmoji(false);
-                        }}
-                        theme="light"
-                        height={260}
-                        width={260}
-                        searchDisabled={false}
-                        emojiStyle="native"
-                        lazyLoadEmojis={true}
-                        skinTonesDisabled={false}
-                        previewConfig={{ showPreview: false }}
-                      />
-                    </div>
-                  </div>
-                )}
+
+                {/* Picker ahora anclado sobre el botón */}
               </div>
             </div>
           </div>
@@ -462,7 +435,77 @@ export default function EditPublicationModal({ open, onClose, onEdit, loading, i
           </div>
         </div>
       </div>
-      <SuccessModal open={showSuccess} />
+
+      {viewerOpen && combinedMedia.length > 0 && (
+        <div
+          className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 backdrop-blur-sm animate-fadeIn"
+          onClick={closeViewer}
+        >
+          <div
+            className="relative w-full max-w-4xl mx-4 bg-white rounded-2xl border border-[#c6e3e4] flex flex-col items-center justify-center p-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={closeViewer}
+              className="absolute z-20 top-4 right-4 w-9 h-9 flex items-center justify-center bg-white/90 hover:bg-white text-conexia-green rounded-full shadow-md border border-[#c6e3e4] transition-colors focus:outline-none focus:ring-2 focus:ring-conexia-green/40"
+              aria-label="Cerrar visor"
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+            </button>
+            <div className="w-full h-[70vh] flex items-center justify-center relative select-none bg-[#f8fcfc] rounded-xl border border-[#e0f0f0]">
+              {(() => {
+                const current = combinedMedia[viewerIndex];
+                if (current.kind === 'original') {
+                  if (current.type === 'image' || current.type === 'gif') {
+                    return <img src={current.url} alt="original" className="max-h-full max-w-full object-contain" />;
+                  }
+                  if (current.type === 'video') {
+                    return <video src={current.url} controls autoPlay className="max-h-full max-w-full object-contain" />;
+                  }
+                } else if (current.kind === 'new') {
+                  const f = current.file;
+                  if (f.type.startsWith('image/')) {
+                    return <img src={URL.createObjectURL(f)} alt={`preview-${viewerIndex}`} className="max-h-full max-w-full object-contain" />;
+                  }
+                  if (f.type.startsWith('video/')) {
+                    return <video src={URL.createObjectURL(f)} controls autoPlay className="max-h-full max-w-full object-contain" />;
+                  }
+                }
+                return <div className="text-conexia-green">Archivo</div>;
+              })()}
+              {combinedMedia.length > 1 && (
+                <>
+                  <button
+                    onClick={prevViewer}
+                    className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center"
+                  >
+                    ‹
+                  </button>
+                  <button
+                    onClick={nextViewer}
+                    className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center"
+                  >
+                    ›
+                  </button>
+                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
+                    {combinedMedia.map((_, i) => (
+                      <button
+                        key={i}
+                        onClick={() => setViewerIndex(i)}
+                        className={`w-3 h-3 rounded-full ${i === viewerIndex ? 'bg-white' : 'bg-white/40'}`}
+                        aria-label={`Ir a ${i + 1}`}
+                      />
+                    ))}
+                  </div>
+                  <div className="absolute top-3 left-4 text-white/80 text-sm bg-black/40 px-3 py-1 rounded-full">
+                    {viewerIndex + 1} / {combinedMedia.length}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/conexia_front/src/components/activity/EditPublicationModalMultiple.jsx
+++ b/conexia_front/src/components/activity/EditPublicationModalMultiple.jsx
@@ -1,41 +1,22 @@
 "use client";
 import PropTypes from 'prop-types';
 import Button from '@/components/ui/Button';
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { FaGlobeAmericas, FaUsers } from 'react-icons/fa';
 import { BsEmojiSmile } from 'react-icons/bs';
-import MediaPreview from '@/components/ui/MediaPreview';
-import ExistingMediaPreview from '@/components/ui/ExistingMediaPreview';
 import { editPublicationWithMedia } from '@/service/publications/editPublication';
 import { config } from '@/config';
+import { buildMediaUrl, getMediaUrlFromObject } from '@/utils/mediaUrl';
 
 const Picker = dynamic(() => import('emoji-picker-react'), { ssr: false });
 const MAX_DESCRIPTION = 500;
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'video/mp4'];
 const MAX_FILES = 5;
 const MAX_VIDEOS = 1;
-const FILES_LEGEND = 'Hasta 5 archivos, solo 1 video por publicación. Formatos permitidos: JPG, PNG, GIF, MP4.';
+const FILES_LEGEND = 'Hasta 5 archivos. Formatos permitidos: JPG, PNG, GIF, MP4. Máx. 1 video por publicación.';
 
-// Modal de éxito
-
-// Modal de éxito
-function SuccessModal({ open }) {
-  if (!open) return null;
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/20">
-      <div className="bg-white border border-[#c6e3e4] rounded-2xl shadow-2xl flex flex-col items-center px-8 py-8 animate-fadeIn">
-        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-conexia-green/10 mb-4">
-          <svg width="40" height="40" viewBox="0 0 24 24" fill="none">
-            <circle cx="12" cy="12" r="12" fill="#e0f0f0"/>
-            <path d="M7 13.5l3 3 7-7" stroke="#1e6e5c" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </div>
-        <div className="text-conexia-green text-lg font-semibold mb-2">Publicación actualizada con éxito</div>
-      </div>
-    </div>
-  );
-}
+// (Eliminado buildMediaUrl local duplicado; usamos util central)
 
 // Modal de privacidad
 function VisibilityModal({ open, onClose, value, onChange }) {
@@ -135,7 +116,6 @@ export default function EditPublicationModalMultiple({
   publication,
   user 
 }) {
-  const [showSuccess, setShowSuccess] = useState(false);
   const [description, setDescription] = useState('');
   const [newFiles, setNewFiles] = useState([]);
   const [existingMedia, setExistingMedia] = useState([]);
@@ -146,20 +126,55 @@ export default function EditPublicationModalMultiple({
   const [showEmoji, setShowEmoji] = useState(false);
   const [submitLoading, setSubmitLoading] = useState(false);
   const [submitError, setSubmitError] = useState('');
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(0);
   
   const fileInputRef = useRef();
   const textareaRef = useRef();
+
+  // Lista combinada para previews y viewer (existing activos + nuevos)
+  const activeExisting = existingMedia.filter(m => !removedMediaIds.includes(m.id));
+  const combinedMedia = [
+    ...activeExisting.map(m => ({ kind: 'existing', media: m })),
+    ...newFiles.map(f => ({ kind: 'new', file: f }))
+  ];
+
+  // Auto-resize textarea similar al modal de creación
+  const MIN_TEXTAREA_HEIGHT = 38;
+  const adjustTextareaHeight = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.max(MIN_TEXTAREA_HEIGHT, el.scrollHeight) + 'px';
+  }, []);
 
   // Inicializar datos cuando se abre el modal
   useEffect(() => {
     if (open && publication) {
       setDescription(publication.description || '');
-      setExistingMedia(publication.media || []);
+
+      // Fallback legacy: si el backend aun usa mediaUrl/mediaType (single) y media[] está vacío
+      if ((!publication.media || publication.media.length === 0) && publication.mediaUrl) {
+        const legacyType = publication.mediaType || '';
+        const mappedFileType = legacyType === 'video' ? 'video/mp4' : legacyType === 'gif' ? 'image/gif' : legacyType === 'image' ? 'image/jpeg' : legacyType;
+        const virtualMedia = {
+          id: 'legacy-0',
+          fileUrl: publication.mediaUrl,
+          filename: publication.mediaFilename || publication.mediaUrl.split('/').pop(),
+          fileType: mappedFileType || 'image/jpeg'
+        };
+        setExistingMedia([virtualMedia]);
+      } else {
+        setExistingMedia(publication.media || []);
+      }
+
       setRemovedMediaIds([]);
       setNewFiles([]);
       setFileError('');
       setSubmitError('');
-      
+      // Reset textarea height on open
+      setTimeout(() => adjustTextareaHeight(), 0);
+
       // Mapear privacy del backend al formato del frontend
       if (publication.privacy === 'public') {
         setVisibility('all');
@@ -170,6 +185,11 @@ export default function EditPublicationModalMultiple({
       }
     }
   }, [open, publication]);
+
+  // Ajustar altura cuando cambia descripción
+  useEffect(() => {
+    adjustTextareaHeight();
+  }, [description, adjustTextareaHeight]);
 
   const handleClose = () => {
     setDescription('');
@@ -258,13 +278,10 @@ export default function EditPublicationModalMultiple({
 
   const handleEdit = async () => {
     if (!description.trim() || submitLoading) return;
-    
     setSubmitLoading(true);
     setSubmitError('');
-    
     try {
       const privacy = visibility === 'contacts' ? 'onlyFriends' : 'public';
-      
       const result = await editPublicationWithMedia({
         id: publication.id,
         description,
@@ -272,17 +289,16 @@ export default function EditPublicationModalMultiple({
         removeMediaIds: removedMediaIds,
         privacy
       });
-      
-      if (onEdit) onEdit(result.data);
-      
-      setShowSuccess(true);
-      setTimeout(() => {
-        setShowSuccess(false);
-        handleClose();
-      }, 1500);
-      
+      if (onEdit) {
+        try { onEdit({ success: true, data: result.data }); } catch(e) { /* ignore */ }
+      }
+      handleClose();
     } catch (error) {
       setSubmitError(error.message || 'Error al actualizar publicación');
+      if (onEdit) {
+        try { onEdit({ success: false, error: error.message || 'Error al actualizar publicación' }); } catch(e) { /* ignore */ }
+      }
+      handleClose();
     } finally {
       setSubmitLoading(false);
     }
@@ -304,183 +320,208 @@ export default function EditPublicationModalMultiple({
     }, 0);
   };
 
-  if (!open && !showSuccess) return null;
+  // Viewer control callbacks must be declared before any conditional returns so hook order stays stable
+  const openViewerAt = useCallback((idx) => {
+    setViewerIndex(idx);
+    setViewerOpen(true);
+  }, []);
+  const closeViewer = useCallback(() => setViewerOpen(false), []);
+  // Navegación del visor usando combinedMedia ya definido más arriba
+  const nextViewer = useCallback(() => {
+    if (combinedMedia.length === 0) return;
+    setViewerIndex(i => (i + 1) % combinedMedia.length);
+  }, [combinedMedia.length]);
+  const prevViewer = useCallback(() => {
+    if (combinedMedia.length === 0) return;
+    setViewerIndex(i => (i - 1 + combinedMedia.length) % combinedMedia.length);
+  }, [combinedMedia.length]);
+
+  // Safe early return AFTER all hooks
+  if (!open) return null;
 
   return (
     <>
-      <SuccessModal open={showSuccess} />
-      
       <div className={open ? "fixed inset-0 z-50 flex justify-center items-center min-h-screen bg-black/30 backdrop-blur-sm" : "hidden"}>
         <VisibilityModal
           open={showVisibilityModal}
           onClose={() => setShowVisibilityModal(false)}
           value={visibility}
-          onChange={(v) => {
-            setVisibility(v);
-            setShowVisibilityModal(false);
-          }}
+          onChange={(v) => { setVisibility(v); setShowVisibilityModal(false); }}
         />
-
         <div className="bg-white rounded-2xl shadow-2xl border border-[#c6e3e4] w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col animate-fadeIn">
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-[#e0f0f0]">
             <div className="flex items-center gap-3">
               <img
-                src={user?.profilePicture?.startsWith('http') 
-                  ? user.profilePicture 
-                  : user?.profilePicture 
-                    ? `${config.IMAGE_URL}/${user.profilePicture}` 
-                    : '/images/default-avatar.png'
-                }
+                src={user?.profilePicture?.startsWith('http')
+                  ? user.profilePicture
+                  : user?.profilePicture
+                    ? `${config.IMAGE_URL}/${user.profilePicture}`
+                    : '/images/default-avatar.png'}
                 alt="avatar"
                 className="w-12 h-12 rounded-full border-2 border-[#c6e3e4] object-cover"
               />
               <div className="flex flex-col">
-                <span className="font-semibold text-conexia-green text-lg">
-                  {user?.displayName || 'Usuario'}
-                </span>
-                <button
-                  onClick={() => setShowVisibilityModal(true)}
-                  className="flex items-center gap-1 text-sm text-conexia-green/70 hover:text-conexia-green transition-colors"
-                >
+                <span className="font-semibold text-conexia-green text-lg">{user?.displayName || 'Usuario'}</span>
+                <button onClick={() => setShowVisibilityModal(true)} className="flex items-center gap-1 text-sm text-conexia-green/70 hover:text-conexia-green transition-colors">
                   {visibility === 'all' ? <FaGlobeAmericas /> : <FaUsers />}
                   <span>{visibility === 'all' ? 'Público' : 'Solo amigos'}</span>
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
                 </button>
               </div>
             </div>
             <button onClick={handleClose} className="text-conexia-green hover:bg-[#e0f0f0] rounded-full p-2 transition-colors">
-              <svg width="24" height="24" fill="none" viewBox="0 0 20 20">
-                <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-              </svg>
+              <svg width="24" height="24" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
             </button>
           </div>
-
           {/* Body */}
-          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4 overflow-hidden">
+          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4 overflow-x-hidden">
             <div className="w-full max-w-xl flex flex-col items-center justify-center">
-              <div className="flex flex-col w-full">
-                <div className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-auto w-full" style={{ minHeight: 160, maxHeight: 300, borderBottom: 'none' }}>
-                  <div className="flex flex-col gap-2 px-1 pt-3 pb-3 w-full overflow-hidden">
+              <div className="flex flex-col w-full" style={{ alignItems:'center' }}>
+                <div className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-auto overflow-x-hidden w-full" style={{ minHeight:160, maxHeight:320, margin:0, borderBottom:'none' }}>
+                  <div className="flex flex-col gap-2 px-1 pt-3 pb-3 w-full">
                     <textarea
                       ref={textareaRef}
                       className="w-full border-none outline-none bg-transparent resize-none text-conexia-green placeholder:text-conexia-green/50 text-base"
                       placeholder="¿Qué tienes en mente?"
                       maxLength={MAX_DESCRIPTION}
                       value={description}
-                      onChange={(e) => setDescription(e.target.value)}
-                      style={{ minHeight: 38, height: 'auto', margin: '8px', overflow: 'hidden', resize: 'none' }}
-                      rows={3}
+                      onChange={(e)=>setDescription(e.target.value)}
+                      style={{ minHeight:MIN_TEXTAREA_HEIGHT, height:'auto', margin:'8px', overflow:'hidden', resize:'none' }}
+                      rows={1}
                     />
-                    
-                    {/* Medios existentes */}
-                    {existingMedia.length > 0 && (
-                      <div className="px-2 w-full overflow-hidden">
-                        <h4 className="text-sm font-medium text-conexia-green mb-2">Archivos actuales:</h4>
-                        <ExistingMediaPreview 
-                          media={existingMedia}
-                          removedIds={removedMediaIds}
-                          onToggleRemove={handleToggleExistingMedia}
-                        />
+                    {/* Grid combinado (2 columnas) de medios existentes + nuevos */}
+                    <div className="px-2">
+                      <div className="grid grid-cols-2 gap-3">
+                        {combinedMedia.map((item, idx) => {
+                          if (item.kind === 'existing') {
+                            const m = item.media;
+                            const mediaUrl = getMediaUrlFromObject(m);
+                            const isVideo = (m.fileType || m.mediaType || '').startsWith('video/');
+                            return (
+                              <div key={`exist-${m.id}`} className="relative group aspect-square w-full bg-[#eef6f6] border border-[#c6e3e4] rounded-xl flex items-center justify-center overflow-hidden cursor-pointer" onClick={() => openViewerAt(idx)}>
+                                {isVideo ? (
+                                  <video src={mediaUrl} className="object-cover w-full h-full" muted />
+                                ) : (
+                                  <img src={mediaUrl} alt={m.filename || 'media'} className="object-cover w-full h-full" />
+                                )}
+                                <button
+                                  type="button"
+                                  onClick={(e) => { e.stopPropagation(); handleToggleExistingMedia(m.id); }}
+                                  className="absolute top-1 right-1 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow opacity-0 group-hover:opacity-100 transition"
+                                >
+                                  <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+                                </button>
+                                <span className="absolute bottom-1 left-1 bg-black/40 text-white text-[10px] px-2 py-0.5 rounded-full">{idx + 1}</span>
+                              </div>
+                            );
+                          }
+                          const f = item.file;
+                          const isVid = f.type.startsWith('video/');
+                          return (
+                            <div key={`new-${idx}`} className="relative group aspect-square w-full bg-[#eef6f6] border border-[#c6e3e4] rounded-xl flex items-center justify-center overflow-hidden cursor-pointer" onClick={() => openViewerAt(idx)}>
+                              {isVid ? (
+                                <video src={URL.createObjectURL(f)} className="object-cover w-full h-full" />
+                              ) : (
+                                <img src={URL.createObjectURL(f)} alt={`nuevo-${idx}`} className="object-cover w-full h-full" />
+                              )}
+                              <button
+                                type="button"
+                                onClick={(e) => { e.stopPropagation(); handleRemoveNewFile(idx - activeExisting.length); }}
+                                className="absolute top-1 right-1 bg-white/80 hover:bg-white text-red-500 rounded-full p-1 shadow opacity-0 group-hover:opacity-100 transition"
+                              >
+                                <svg width="18" height="18" fill="none" viewBox="0 0 20 20"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+                              </button>
+                              <span className="absolute bottom-1 left-1 bg-black/40 text-white text-[10px] px-2 py-0.5 rounded-full">{idx + 1}</span>
+                            </div>
+                          );
+                        })}
                       </div>
-                    )}
-                    
-                    {/* Nuevos archivos */}
-                    <div className="px-2 w-full overflow-hidden">
-                      {newFiles.length > 0 && (
-                        <h4 className="text-sm font-medium text-conexia-green mb-2">Nuevos archivos:</h4>
+                      {fileError && <div className="text-red-500 text-xs mt-1">{fileError}</div>}
+                      {submitError && <div className="text-red-500 text-xs mt-1">{submitError}</div>}
+                    </div>
+                  </div>
+                </div>
+                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin:0 }}>
+                  <div className="px-4 pt-2 pb-1"><div className="text-[11px] text-conexia-green/60 leading-snug">{FILES_LEGEND}</div></div>
+                  <div className="h-px bg-[#e0f0f0] mx-3" />
+                  <div className="flex items-center gap-3 px-3 pt-2 pb-2">
+                    <div className="relative">
+                      <button type="button" className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green" onClick={()=>setShowEmoji(v=>!v)} title="Emoji"><BsEmojiSmile /></button>
+                      {showEmoji && (
+                        <div className="absolute bottom-full mb-2 left-0 z-50">
+                          <div className="relative bg-white rounded-xl shadow-xl border border-[#c6e3e4] overflow-hidden" style={{ width:260, height:260 }}>
+                            <Picker
+                              onEmojiClick={(emojiData)=>{handleEmojiClick(emojiData); setShowEmoji(false);}}
+                              theme="light"
+                              height={260}
+                              width={260}
+                              searchDisabled={false}
+                              emojiStyle="native"
+                              lazyLoadEmojis={true}
+                              skinTonesDisabled={false}
+                              previewConfig={{ showPreview:false }}
+                            />
+                          </div>
+                        </div>
                       )}
-                      <MediaPreview 
-                        files={newFiles} 
-                        onRemove={handleRemoveNewFile}
-                        maxFiles={MAX_FILES}
-                      />
                     </div>
+                    <button type="button" onClick={()=>handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent hover:bg-[#e0f0f0]"><svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><circle cx="8" cy="10" r="2" fill="#1e6e5c"/><path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/></svg></button>
+                    <button type="button" onClick={()=>handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent hover:bg-[#e0f0f0]"><svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><polygon points="10,9 16,12 10,15" fill="#1e6e5c"/></svg></button>
+                    <button type="button" onClick={()=>handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent hover:bg-[#e0f0f0]"><svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text></svg></button>
+                    <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
                   </div>
                 </div>
-                
-                {/* Controles */}
-                <div className="flex items-center gap-3 px-3 py-2 border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl w-full" style={{ margin: 0 }}>
-                  <button
-                    type="button"
-                    className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
-                    onClick={() => setShowEmoji(v => !v)}
-                    title="Emoji"
-                  >
-                    <BsEmojiSmile />
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none hover:bg-[#e0f0f0]">
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24">
-                      <rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/>
-                      <circle cx="8" cy="10" r="2" fill="#1e6e5c"/>
-                      <path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/>
-                    </svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none hover:bg-[#e0f0f0]">
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24">
-                      <rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/>
-                      <polygon points="10,9 16,12 10,15" fill="#1e6e5c"/>
-                    </svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none hover:bg-[#e0f0f0]">
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24">
-                      <rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/>
-                      <text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text>
-                    </svg>
-                  </button>
-                  <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
-                </div>
-                
                 <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} multiple />
-                
-                {fileError && <div className="text-red-500 text-xs mt-2 px-2">{fileError}</div>}
-                {submitError && <div className="text-red-500 text-xs mt-2 px-2">{submitError}</div>}
-
-                {showEmoji && (
-                  <div className="absolute bottom-20 left-6 z-50">
-                    <div className="fixed inset-0 z-40" onClick={() => setShowEmoji(false)} />
-                    <div className="relative z-50 bg-white rounded-xl shadow-xl overflow-hidden" style={{ width: 260, height: 260 }}>
-                      <Picker
-                        onEmojiClick={(emojiData) => {
-                          handleEmojiClick(emojiData);
-                          setShowEmoji(false);
-                        }}
-                        theme="light"
-                        height={260}
-                        width={260}
-                        searchDisabled={false}
-                        emojiStyle="native"
-                        lazyLoadEmojis={true}
-                        skinTonesDisabled={false}
-                        previewConfig={{ showPreview: false }}
-                      />
-                    </div>
-                  </div>
-                )}
+                {/* Picker ahora anclado sobre el botón dentro del contenedor relativo */}
               </div>
             </div>
           </div>
-
-          {/* Footer */}
-          <div className="flex flex-col items-end gap-2 p-4 border-t border-[#e0f0f0] bg-[#eef6f6] rounded-b-2xl">
-            <div className="w-full text-xs text-conexia-green/60 mb-2 text-left">{FILES_LEGEND}</div>
-            <div className="flex items-center justify-end gap-2 w-full">
-              <Button type="button" variant="cancel" onClick={handleClose} className="!px-4 !py-2 !rounded-lg">
-                Cancelar
-              </Button>
-              <Button
-                onClick={handleEdit}
-                disabled={!description.trim() || submitLoading}
-                className="!px-4 !py-2 !rounded-lg bg-conexia-green hover:bg-[#0d5951] text-white disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {submitLoading ? 'Actualizando...' : 'Actualizar publicación'}
-              </Button>
+          <div className="flex items-center justify-end gap-2 p-4 border-t border-[#e0f0f0] bg-[#eef6f6] rounded-b-2xl">
+            <Button type="button" variant="cancel" onClick={handleClose} className="!px-4 !py-2 !rounded-lg">Cancelar</Button>
+            <Button onClick={handleEdit} disabled={!description.trim() || submitLoading} className="!px-6 !py-2 !rounded-lg">{submitLoading ? 'Actualizando...' : 'Actualizar publicación'}</Button>
+          </div>
+          {submitError && <div className="text-red-500 text-xs text-center pb-2">{submitError}</div>}
+        </div>
+      </div>
+      {viewerOpen && combinedMedia.length > 0 && (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 backdrop-blur-sm animate-fadeIn" onClick={closeViewer}>
+          <div className="relative w-full max-w-4xl mx-4 bg-white rounded-2xl border border-[#c6e3e4] flex flex-col items-center justify-center p-4 shadow-2xl" onClick={(e)=>e.stopPropagation()}>
+            <button onClick={closeViewer} className="absolute z-20 top-4 right-4 w-9 h-9 flex items-center justify-center bg-white/90 hover:bg-white text-conexia-green rounded-full shadow-md border border-[#c6e3e4] transition-colors focus:outline-none focus:ring-2 focus:ring-conexia-green/40" aria-label="Cerrar visor">
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+            </button>
+            <div className="w-full h-[70vh] flex items-center justify-center relative select-none bg-[#f8fcfc] rounded-xl border border-[#e0f0f0]">
+              {(() => {
+                const current = combinedMedia[viewerIndex];
+                if (current.kind === 'existing') {
+                  const m = current.media;
+                  const mediaUrl = getMediaUrlFromObject(m);
+                  const type = m.fileType || m.mediaType || '';
+                  if (type.startsWith('image/')) return <img src={mediaUrl} alt={m.filename} className="max-h-full max-w-full object-contain" />;
+                  if (type.startsWith('video/')) return <video src={mediaUrl} controls autoPlay className="max-h-full max-w-full object-contain" />;
+                } else if (current.kind === 'new') {
+                  const f = current.file;
+                  if (f.type.startsWith('image/')) return <img src={URL.createObjectURL(f)} alt={`preview-${viewerIndex}`} className="max-h-full max-w-full object-contain" />;
+                  if (f.type.startsWith('video/')) return <video src={URL.createObjectURL(f)} controls autoPlay className="max-h-full max-w-full object-contain" />;
+                }
+                return <div className="text-conexia-green">Archivo</div>;
+              })()}
+              {combinedMedia.length > 1 && (
+                <>
+                  <button onClick={prevViewer} className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center">‹</button>
+                  <button onClick={nextViewer} className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center">›</button>
+                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
+                    {combinedMedia.map((_, i) => (
+                      <button key={i} onClick={()=>setViewerIndex(i)} className={`w-3 h-3 rounded-full ${i===viewerIndex ? 'bg-white' : 'bg-white/40'}`} aria-label={`Ir a ${i+1}`} />
+                    ))}
+                  </div>
+                  <div className="absolute top-3 left-4 text-white/80 text-sm bg-black/40 px-3 py-1 rounded-full">{viewerIndex + 1} / {combinedMedia.length}</div>
+                </>
+              )}
             </div>
           </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/conexia_front/src/components/activity/EditPublicationModalMultiple.jsx
+++ b/conexia_front/src/components/activity/EditPublicationModalMultiple.jsx
@@ -437,14 +437,23 @@ export default function EditPublicationModalMultiple({
                           );
                         })}
                       </div>
-                      {fileError && <div className="text-red-500 text-xs mt-1">{fileError}</div>}
-                      {submitError && <div className="text-red-500 text-xs mt-1">{submitError}</div>}
+                      {/* fileError and submitError moved to static area above legend */}
                     </div>
                   </div>
                 </div>
-                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin:0 }}>
-                  <div className="px-4 pt-2 pb-1"><div className="text-[11px] text-conexia-green/60 leading-snug">{FILES_LEGEND}</div></div>
-                  <div className="h-px bg-[#e0f0f0] mx-3" />
+                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl relative" style={{ margin:0 }}>
+                  <div className="px-4 pt-2">
+                    <div className="min-h-[26px] flex flex-col gap-1" aria-live="polite" aria-atomic="true">
+                      {fileError && (
+                        <div className="bg-red-50 border border-red-200 text-red-600 text-[11px] px-3 py-1 rounded-md text-center shadow-sm w-full" role="alert">{fileError}</div>
+                      )}
+                      {submitError && !fileError && (
+                        <div className="bg-red-50 border border-red-200 text-red-600 text-[11px] px-3 py-1 rounded-md text-center shadow-sm w-full" role="alert">{submitError}</div>
+                      )}
+                    </div>
+                    <div className="text-[11px] text-conexia-green/60 leading-snug mt-1">{FILES_LEGEND}</div>
+                  </div>
+                  <div className="h-px bg-[#e0f0f0] mx-3 mt-2" />
                   <div className="flex items-center gap-3 px-3 pt-2 pb-2">
                     <div className="relative">
                       <button type="button" className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green" onClick={()=>setShowEmoji(v=>!v)} title="Emoji"><BsEmojiSmile /></button>

--- a/conexia_front/src/components/activity/UserActivitiesFeed.jsx
+++ b/conexia_front/src/components/activity/UserActivitiesFeed.jsx
@@ -3,6 +3,7 @@ import PublicationCard from './PublicationCard';
 import { getProfilePublications } from '@/service/publications/profilePublicationsFetch';
 import { getProfileById } from '@/service/profiles/profilesFetch';
 import ProfileSidebar from '@/components/profile/ProfileSidebar';
+import Toast from '@/components/ui/Toast';
 
 export default function UserActivitiesFeed({ userId }) {
   const [profile, setProfile] = useState(null);
@@ -13,6 +14,7 @@ export default function UserActivitiesFeed({ userId }) {
   const [hasMore, setHasMore] = useState(true);
   const [profileLoading, setProfileLoading] = useState(true);
   const limit = 10;
+  const [toast, setToast] = useState(null);
 
   // Obtener perfil del usuario a mostrar
   useEffect(() => {
@@ -87,7 +89,7 @@ export default function UserActivitiesFeed({ userId }) {
               <div className="text-conexia-green/70">No hay publicaciones para mostrar.</div>
             )}
             {publications.map(pub => (
-              <PublicationCard key={pub.id} publication={pub} />
+              <PublicationCard key={pub.id} publication={pub} onShowToast={(t)=> setToast(t)} />
             ))}
             {loading && publications.length > 0 && (
               <div className="text-conexia-green/70 py-4 text-center">Cargando más publicaciones...</div>
@@ -96,6 +98,16 @@ export default function UserActivitiesFeed({ userId }) {
               <div className="text-conexia-green/60 py-4 text-center">No hay más publicaciones.</div>
             )}
           </div>
+          {toast && (
+            <Toast
+              type={toast.type}
+              message={toast.message}
+              isVisible={toast.isVisible}
+              onClose={() => setToast(null)}
+              position="top-center"
+              duration={4000}
+            />
+          )}
         </div>
       </div>
     </main>

--- a/conexia_front/src/components/activity/report/ReportPublicationModal.jsx
+++ b/conexia_front/src/components/activity/report/ReportPublicationModal.jsx
@@ -15,7 +15,6 @@ export default function ReportPublicationModal({ onCancel, onSubmit, loading }) 
   const [otherText, setOtherText] = useState("");
   const [description, setDescription] = useState("");
   const [error, setError] = useState("");
-  const [msg, setMsg] = useState(null);
   const handleReasonChange = (reason) => {
     setSelectedReason(reason);
     if (reason !== "Otro") {
@@ -24,7 +23,6 @@ export default function ReportPublicationModal({ onCancel, onSubmit, loading }) 
   };
   const handleSubmit = () => {
     setError("");
-    setMsg(null);
     if (!selectedReason) {
       setError("Debes seleccionar un motivo.");
       return;
@@ -41,11 +39,12 @@ export default function ReportPublicationModal({ onCancel, onSubmit, loading }) 
       setError("La descripción es obligatoria.");
       return;
     }
+    // Delegamos totalmente el feedback al padre (toast + cierre)
     onSubmit({
       reason: selectedReason,
       other: selectedReason === "Otro" ? otherText : undefined,
       description,
-    }, setMsg);
+    });
   };
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex justify-center items-center overflow-auto">
@@ -109,15 +108,7 @@ export default function ReportPublicationModal({ onCancel, onSubmit, loading }) 
           />
         </div>
         {error && <div className="text-red-500 text-sm mb-2">{error}</div>}
-        {msg && (
-          <div className={`text-sm mb-2 ${
-            typeof msg === 'object' 
-              ? (msg.ok ? 'text-green-600' : 'text-red-600')
-              : 'text-conexia-green'
-          }`}>
-            {typeof msg === 'object' ? msg.text : msg}
-          </div>
-        )}
+        {/* Feedback visual (éxito/error) ahora se muestra mediante Toast externo y el modal se cierra automáticamente tras el intento */}
         <div className="flex justify-end gap-2 mt-4">
           <Button onClick={onCancel} variant="secondary" disabled={loading}>Cancelar</Button>
           <Button onClick={handleSubmit} variant="primary" disabled={loading}>

--- a/conexia_front/src/components/admin/internal-users/DeleteInternalUserModal.jsx
+++ b/conexia_front/src/components/admin/internal-users/DeleteInternalUserModal.jsx
@@ -1,25 +1,27 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Button from '@/components/ui/Button';
 
-export default function DeleteInternalUserModal({ email, onConfirm, onCancel, loading, onUserDeleted }) {
-  const [msg, setMsg] = useState(null);
-
-  useEffect(() => {
-    if (msg?.ok) {
-      const timeout = setTimeout(() => {
-        setMsg(null);
-        onCancel();       // Cierra el modal
-        if (onUserDeleted) onUserDeleted(); // Refresca grilla después del cierre
-      }, 1500);
-      return () => clearTimeout(timeout);
-    }
-  }, [msg, onCancel, onUserDeleted]);
+export default function DeleteInternalUserModal({ email, onConfirm, onCancel, loading, onUserDeleted, onError }) {
+  const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = async () => {
-    const result = await onConfirm(); // { ok, text }
-    setMsg(result);
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      const result = await onConfirm(); // Se espera que retorne { ok, text }
+      if (result?.ok) {
+        if (onUserDeleted) onUserDeleted(result.text);
+        onCancel();
+      } else {
+        if (onError) onError(result?.text || 'Error al eliminar usuario interno.');
+      }
+    } catch (e) {
+      if (onError) onError('Error al eliminar usuario interno.');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -33,19 +35,13 @@ export default function DeleteInternalUserModal({ email, onConfirm, onCancel, lo
             ¿Estás seguro que deseas eliminar al usuario <span className="font-semibold">{email}</span>?
             </p>
 
-            <div className="min-h-[40px] text-center text-sm transition-all duration-300 mb-2">
-            {msg && (
-                <p className={msg.ok ? 'text-green-600' : 'text-red-600'}>
-                {msg.text}
-                </p>
-            )}
-            </div>
+      {/* Mensajes internos eliminados: ahora se muestran vía Toast externo */}
 
             <div className="flex justify-end gap-2 mt-4">
-            <Button variant="danger" onClick={handleSubmit} disabled={loading}>
-                {loading ? 'Eliminando...' : 'Eliminar'}
+      <Button variant="danger" onClick={handleSubmit} disabled={loading || submitting}>
+        {loading || submitting ? 'Eliminando...' : 'Eliminar'}
             </Button>
-            <Button variant="cancel" onClick={onCancel} disabled={loading}>
+      <Button variant="cancel" onClick={onCancel} disabled={loading || submitting}>
                 Cancelar
             </Button>
             </div>

--- a/conexia_front/src/components/admin/internal-users/EditInternalUserModal.jsx
+++ b/conexia_front/src/components/admin/internal-users/EditInternalUserModal.jsx
@@ -9,7 +9,7 @@ import { useInternalRoles } from '@/hooks/internal-users/useInternalRoles';
 import useUpdateInternalUser from '@/hooks/internal-users/useUpdateInternalUser';
 import { ROLES, ROLES_NAME } from '@/constants/roles';
 
-export default function EditInternalUserModal({ user, onClose, onUserUpdated }) {
+export default function EditInternalUserModal({ user, onClose, onUserUpdated, onError }) {
   const { roles } = useInternalRoles(); // [{ key: 1, value: 'admin' }, { key: 3, value: 'moderador' }]
   const { handleUpdate, updatingId } = useUpdateInternalUser();
 
@@ -21,7 +21,7 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
   const [initialRoleId, setInitialRoleId] = useState('');
   const [touched, setTouched] = useState({});
   const [showPwd, setShowPwd] = useState(false);
-  const [msg, setMsg] = useState(null);
+  // Mensajes internos reemplazados por Toast externo
 
   const isAdmin = user.role === ROLES.ADMIN;
   const isModerator = user.role === ROLES.MODERATOR;
@@ -38,23 +38,7 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
     }
   }, [roles, user.role]);
 
-  useEffect(() => {
-    if (msg?.ok) {
-      const timeout = setTimeout(() => {
-        setMsg(null);
-        onClose();
-        if (onUserUpdated) onUserUpdated();
-      }, 1500);
-      return () => clearTimeout(timeout);
-    }
-  }, [msg, onClose, onUserUpdated]);
-
-  useEffect(() => {
-    if (msg && !msg.ok) {
-      const timeout = setTimeout(() => setMsg(null), 5000);
-      return () => clearTimeout(timeout);
-    }
-  }, [msg]);
+  // Eliminado: manejo temporal de mensajes locales
 
   const handleChange = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
@@ -102,7 +86,7 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
     const isRoleChanged = form.roleId.toString() !== initialRoleId.toString();
 
     if (!isPasswordChanged && !isRoleChanged) {
-      setMsg({ ok: false, text: 'No se está haciendo ninguna actualización.' });
+  if (onError) onError('No se está haciendo ninguna actualización.');
       return;
     }
 
@@ -121,7 +105,8 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
       const fieldsText = changedFields.join(' y ');
       const successMessage = `Usuario actualizado correctamente. Se modifico ${fieldsText}.`;
 
-      setMsg({ ok: true, text: successMessage });
+      if (onUserUpdated) onUserUpdated(successMessage);
+      onClose();
     } catch (error) {
       const message = error.message || '';
       let userFriendlyMessage = 'Ocurrió un error al actualizar el usuario.';
@@ -132,7 +117,7 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
         userFriendlyMessage = 'La nueva contraseña no puede ser igual a la contraseña actual.';
       }
 
-      setMsg({ ok: false, text: userFriendlyMessage });
+      if (onError) onError(userFriendlyMessage);
     }
   };
 
@@ -198,14 +183,7 @@ export default function EditInternalUserModal({ user, onClose, onUserUpdated }) 
             />
           </div>
 
-          {/* Mensaje final */}
-          <div className="min-h-[40px] text-center text-sm transition-all duration-300">
-            {msg && (
-              <p className={msg.ok ? 'text-green-600' : 'text-red-600'}>
-                {msg.text}
-              </p>
-            )}
-          </div>
+          {/* Mensaje final eliminado: feedback vía Toast externo */}
 
           {/* Botones */}
           <div className="flex justify-end gap-2 mt-2">

--- a/conexia_front/src/components/community/ClientCommunity.jsx
+++ b/conexia_front/src/components/community/ClientCommunity.jsx
@@ -9,6 +9,7 @@ import PublicationCard from '@/components/activity/PublicationCard';
 import ProfileSidebar from '@/components/profile/ProfileSidebar';
 import Image from 'next/image';
 import PublicationModal from './publications/PublicationModal';
+import Toast from '@/components/ui/Toast';
 import { useAuth } from '@/context/AuthContext';
 import { useUserStore } from '@/store/userStore';
 import { ROLES } from '@/constants/roles';
@@ -31,6 +32,7 @@ export default function ClientCommunity() {
   const [hasMore, setHasMore] = useState(true);
   const limit = 10;
   const { user: userStore } = useUserStore();
+  const [toast, setToast] = useState(null);
 
   // Hook para recomendaciones
   const { 
@@ -98,9 +100,14 @@ export default function ClientCommunity() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [loadingPublications, hasMore]);
 
-    // Simulación de publicación
-    const handlePublish = (data) => {
-
+    // Resultado de publicación (success/error) proveniente del modal
+    const handlePublish = (result) => {
+      if (!result) return;
+      if (result.success) {
+        setToast({ type: 'success', message: 'Publicación creada con éxito', isVisible: true });
+      } else {
+        setToast({ type: 'error', message: result.error || 'No se pudo crear la publicación', isVisible: true });
+      }
     };
 
     const isInternal = roleName === ROLES.ADMIN || roleName === ROLES.MODERATOR;
@@ -214,6 +221,7 @@ export default function ClientCommunity() {
                   <PublicationCard 
                     key={publicationComplete.id} 
                     publication={publicationComplete} 
+                    onShowToast={(t)=> setToast(t)}
                   />
                 );
               })}
@@ -236,9 +244,17 @@ export default function ClientCommunity() {
           </div>
         </div>
         {/* Widget de mensajería reutilizable */}
-        <MessagingWidget
-          avatar={avatar}
-        />
+        <MessagingWidget avatar={avatar} />
+        {toast && (
+          <Toast
+            type={toast.type}
+            message={toast.message}
+            isVisible={toast.isVisible}
+            onClose={() => setToast(null)}
+            position="top-center"
+            duration={4000}
+          />
+        )}
       </main>
     );
   }

--- a/conexia_front/src/components/community/publications/PublicationModal.jsx
+++ b/conexia_front/src/components/community/publications/PublicationModal.jsx
@@ -1,17 +1,4 @@
-// Modal de éxito tipo toast
-function SuccessModal({ open }) {
-  if (!open) return null;
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/20">
-      <div className="bg-white border border-[#c6e3e4] rounded-2xl shadow-2xl flex flex-col items-center px-8 py-8 animate-fadeIn">
-        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-conexia-green/10 mb-4">
-          <svg width="40" height="40" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="12" fill="#e0f0f0"/><path d="M7 13.5l3 3 7-7" stroke="#1e6e5c" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
-        </div>
-        <div className="text-conexia-green text-lg font-semibold mb-2">Publicación realizada con éxito</div>
-      </div>
-    </div>
-  );
-}
+// (El antiguo SuccessModal se eliminó; ahora se usa Toast externo)
 import { useState, useRef, useEffect } from 'react';
 import Button from '@/components/ui/Button';
 import Image from 'next/image';
@@ -133,7 +120,6 @@ function VisibilityModal({ open, onClose, value, onChange }) {
 }
 
 export default function PublicationModal({ open, onClose, onPublish, user }) {
-  const [showSuccess, setShowSuccess] = useState(false);
   const avatar = user?.profilePicture
     ? `${config.IMAGE_URL}/${user.profilePicture}`
     : '/images/default-avatar.png';
@@ -145,6 +131,9 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
   const [showEmoji, setShowEmoji] = useState(false);
   const fileInputRef = useRef();
   const textareaRef = useRef();
+  // Visor de medios (carousel interno antes de publicar)
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const [viewerIndex, setViewerIndex] = useState(0);
 
   // Ajusta la altura del textarea dinámicamente desde un mínimo hasta un máximo
   const MIN_TEXTAREA_HEIGHT = 38; // 2 líneas aprox
@@ -214,23 +203,30 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
+  // Abrir visor de medios en índice específico
+  const openViewerAt = (idx) => {
+    setViewerIndex(idx);
+    setViewerOpen(true);
+  };
+  const closeViewer = () => setViewerOpen(false);
+  const nextViewer = (e) => { e?.stopPropagation?.(); setViewerIndex((i) => (i + 1) % files.length); };
+  const prevViewer = (e) => { e?.stopPropagation?.(); setViewerIndex((i) => (i - 1 + files.length) % files.length); };
+
   const handlePublish = async () => {
     if (!description.trim() || loading) return;
     setLoading(true);
     setSubmitError('');
-    let privacy = 'public';
-    if (visibility === 'contacts') privacy = 'onlyFriends';
+    let privacy = visibility === 'contacts' ? 'onlyFriends' : 'public';
     try {
-      // Enviar todos los archivos
       await createPublication({ description, files, privacy });
-      if (onPublish) onPublish({ description, files, privacy });
-      setShowSuccess(true);
-      setTimeout(() => {
-        setShowSuccess(false);
-        handleClose();
-      }, 1500);
+      // Notificar inmediatamente y cerrar modal
+      onPublish && onPublish({ success: true, description, privacy });
+      handleClose();
     } catch (err) {
-      setSubmitError(err.message || 'Error al crear publicación');
+      const msg = err?.message || 'Error al crear publicación';
+      setSubmitError(msg);
+      onPublish && onPublish({ success: false, error: msg });
+      handleClose();
     } finally {
       setLoading(false);
     }
@@ -261,7 +257,7 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
     adjustTextareaHeight();
   }, [description]);
 
-  if (!open && !showSuccess) return null;
+  if (!open) return null;
 
   return (
     <>
@@ -276,7 +272,7 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
           }}
         />
 
-  <div className="relative w-full max-w-2xl mx-2 bg-white rounded-2xl shadow-2xl border border-[#c6e3e4] animate-fadeIn flex flex-col" style={{ minHeight: 420, maxHeight: 600 }}>
+  <div className="relative w-full max-w-2xl mx-2 bg-white rounded-2xl shadow-2xl border border-[#c6e3e4] animate-fadeIn flex flex-col" style={{ minHeight: 460, maxHeight: 680 }}>
           {/* Header */}
           <div className="p-4 border-b border-[#e0f0f0] bg-[#eef6f6] rounded-t-2xl">
             <div className="flex items-center gap-3 relative">
@@ -306,16 +302,16 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
           </div>
 
           {/* Body (scrollable, LinkedIn style) */}
-          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4">
+          <div className="flex-1 flex flex-col items-center justify-center px-2 py-4 overflow-x-hidden">
             <div className="w-full max-w-xl flex flex-col items-center justify-center">
               {/* Bloque scrolleable: textarea + previews de archivos */}
               <div className="flex flex-col w-full" style={{ alignItems: 'center' }}>
                 <div
-                  className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-scroll w-full"
+                  className="bg-[#f8fcfc] border border-[#c6e3e4] rounded-t-2xl flex flex-col p-0 relative overflow-y-auto overflow-x-hidden w-full"
                   style={{
                     minHeight: 160,
-                    maxHeight: 280,
-                    height: 280,
+                    maxHeight: 320,
+                    height: 320,
                     margin: 0,
                     borderBottom: 'none',
                   }}
@@ -346,30 +342,39 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
                         files={files} 
                         onRemove={handleRemoveFile}
                         maxFiles={MAX_FILES}
+                        onSelect={openViewerAt}
                       />
                     </div>
                   </div>
                 </div>
-                {/* Controles de adjuntos pegados abajo del input, sin separación */}
-                <div className="flex items-center gap-3 px-3 py-2 border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl w-full" style={{ margin: 0 }}>
-                  <button
-                    type="button"
-                    className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
-                    onClick={() => setShowEmoji((v) => !v)}
-                    title="Emoji"
-                  >
-                    <BsEmojiSmile />
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><circle cx="8" cy="10" r="2" fill="#1e6e5c"/><path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/></svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><polygon points="10,9 16,12 10,15" fill="#1e6e5c"/></svg>
-                  </button>
-                  <button type="button" onClick={() => handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
-                    <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text></svg>
-                  </button>
-                  <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
+                {/* Controles + leyenda (leyenda arriba, sin fondo extra) */}
+                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin: 0 }}>
+                  <div className="px-4 pt-2 pb-1">
+                    <div className="text-[11px] text-conexia-green/60 leading-snug">
+                      {FILES_LEGEND}
+                    </div>
+                  </div>
+                  <div className="h-px bg-[#e0f0f0] mx-3" />
+                  <div className="flex items-center gap-3 px-3 pt-2 pb-2">
+                    <button
+                      type="button"
+                      className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
+                      onClick={() => setShowEmoji((v) => !v)}
+                      title="Emoji"
+                    >
+                      <BsEmojiSmile />
+                    </button>
+                    <button type="button" onClick={() => handleFileIconClick('image')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><circle cx="8" cy="10" r="2" fill="#1e6e5c"/><path d="M21 19l-5.5-7-4.5 6-3-4-4 5" stroke="#1e6e5c" strokeWidth="2" strokeLinecap="round"/></svg>
+                    </button>
+                    <button type="button" onClick={() => handleFileIconClick('video')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><polygon points="10,9 16,12 10,15" fill="#1e6e5c"/></svg>
+                    </button>
+                    <button type="button" onClick={() => handleFileIconClick('gif')} className="flex items-center gap-2 px-4 py-2 rounded-lg bg-transparent border-none focus:outline-none transition-colors hover:bg-[#e0f0f0]" style={{ boxShadow: 'none', border: 'none' }}>
+                      <svg width="20" height="20" fill="none" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="3" fill="#e0f0f0" stroke="#1e6e5c" strokeWidth="2"/><text x="7" y="17" fontSize="8" fill="#1e6e5c">GIF</text></svg>
+                    </button>
+                    <span className="text-xs text-conexia-green/50 ml-auto">{description.length}/{MAX_DESCRIPTION}</span>
+                  </div>
                 </div>
                 <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} multiple />
                 {fileError && <div className="text-red-500 text-xs mb-1">{fileError}</div>}
@@ -406,7 +411,7 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
 
           {/* Footer */}
           <div className="flex flex-col items-end gap-2 p-4 border-t border-[#e0f0f0] bg-[#eef6f6] rounded-b-2xl">
-            <div className="w-full text-xs text-conexia-green/60 mb-2 text-left">{FILES_LEGEND}</div>
+            {/* Legend moved: now displayed directly under the editor area above the icon buttons */}
             <div className="flex items-center justify-end gap-2 w-full">
               <Button type="button" variant="cancel" onClick={handleClose} className="!px-4 !py-2 !rounded-lg">
                 Cancelar
@@ -424,7 +429,72 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
           {submitError && <div className="text-red-500 text-xs text-center pb-2">{submitError}</div>}
         </div>
       </div>
-      <SuccessModal open={showSuccess} />
+      {viewerOpen && files.length > 0 && (
+        <div
+          className="fixed inset-0 z-[120] flex items-center justify-center bg-black/70 backdrop-blur-sm animate-fadeIn"
+          onClick={closeViewer}
+        >
+          <div
+            className="relative w-full max-w-4xl mx-4 bg-white rounded-2xl border border-[#c6e3e4] flex flex-col items-center justify-center p-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={closeViewer}
+              className="absolute z-20 top-4 right-4 w-9 h-9 flex items-center justify-center bg-white/90 hover:bg-white text-conexia-green rounded-full shadow-md border border-[#c6e3e4] transition-colors focus:outline-none focus:ring-2 focus:ring-conexia-green/40"
+              aria-label="Cerrar visor"
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
+            </button>
+            <div className="w-full h-[70vh] flex items-center justify-center relative select-none bg-[#f8fcfc] rounded-xl border border-[#e0f0f0]">
+              {files[viewerIndex].type.startsWith('image/') ? (
+                <img
+                  src={URL.createObjectURL(files[viewerIndex])}
+                  alt={`Preview ${viewerIndex + 1}`}
+                  className="max-h-full max-w-full object-contain"
+                />
+              ) : files[viewerIndex].type.startsWith('video/') ? (
+                <video
+                  src={URL.createObjectURL(files[viewerIndex])}
+                  controls
+                  autoPlay
+                  className="max-h-full max-w-full object-contain"
+                />
+              ) : (
+                <div className="text-white">Archivo</div>
+              )}
+              {files.length > 1 && (
+                <>
+                  <button
+                    onClick={prevViewer}
+                    className="absolute left-2 md:left-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center"
+                  >
+                    ‹
+                  </button>
+                  <button
+                    onClick={nextViewer}
+                    className="absolute right-2 md:right-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 text-white flex items-center justify-center"
+                  >
+                    ›
+                  </button>
+                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-3">
+                    {files.map((_, i) => (
+                      <button
+                        key={i}
+                        onClick={() => setViewerIndex(i)}
+                        className={`w-3 h-3 rounded-full ${i === viewerIndex ? 'bg-white' : 'bg-white/40'}`}
+                        aria-label={`Ir a ${i + 1}`}
+                      />
+                    ))}
+                  </div>
+                  <div className="absolute top-3 left-4 text-white/80 text-sm bg-black/40 px-3 py-1 rounded-full">
+                    {viewerIndex + 1} / {files.length}
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/conexia_front/src/components/community/publications/PublicationModal.jsx
+++ b/conexia_front/src/components/community/publications/PublicationModal.jsx
@@ -348,14 +348,22 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
                   </div>
                 </div>
                 {/* Controles + leyenda (leyenda arriba, sin fondo extra) */}
-                <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl" style={{ margin: 0 }}>
-                  <div className="px-4 pt-2 pb-1">
-                    <div className="text-[11px] text-conexia-green/60 leading-snug">
-                      {FILES_LEGEND}
-                    </div>
-                  </div>
-                  <div className="h-px bg-[#e0f0f0] mx-3" />
-                  <div className="flex items-center gap-3 px-3 pt-2 pb-2">
+                    <div className="w-full border border-[#c6e3e4] border-t-0 bg-[#f8fcfc] rounded-b-2xl relative" style={{ margin: 0 }}>
+                      {/* Static error area above legend */}
+                      <div className="px-4 pt-2">
+                        <div className="min-h-[26px] transition-opacity duration-150 flex items-center justify-center" aria-live="polite" aria-atomic="true">
+                          {fileError && (
+                            <div className="bg-red-50 border border-red-200 text-red-600 text-[11px] px-3 py-1 rounded-md text-center shadow-sm w-full" role="alert">
+                              {fileError}
+                            </div>
+                          )}
+                        </div>
+                        <div className="text-[11px] text-conexia-green/60 leading-snug mt-1">
+                          {FILES_LEGEND}
+                        </div>
+                      </div>
+                      <div className="h-px bg-[#e0f0f0] mx-3 mt-2" />
+                      <div className="flex items-center gap-3 px-3 pt-2 pb-2">
                     <button
                       type="button"
                       className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-[#e0f0f0] text-conexia-green/60 hover:text-conexia-green"
@@ -377,7 +385,6 @@ export default function PublicationModal({ open, onClose, onPublish, user }) {
                   </div>
                 </div>
                 <input ref={fileInputRef} type="file" className="hidden" onChange={handleFileChange} multiple />
-                {fileError && <div className="text-red-500 text-xs mb-1">{fileError}</div>}
 
                 {showEmoji && (
                   <div className="absolute bottom-20 left-6 z-50">

--- a/conexia_front/src/components/connections/ConnectionRequestCard.jsx
+++ b/conexia_front/src/components/connections/ConnectionRequestCard.jsx
@@ -28,6 +28,9 @@ export default function ConnectionRequestCard({ name, profession, image, request
       // Actualizar el contexto para reflejar el cambio en toda la aplicación
       refreshRequests();
       if (onAccepted) onAccepted(requestId);
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('connectionAcceptedToast', JSON.stringify({ type: 'success', message: 'Conexión aceptada.', isVisible: true }));
+      }
     } catch (err) {
       // Opcional: mostrar error
     }

--- a/conexia_front/src/components/connections/ConnectionRequestsSection.jsx
+++ b/conexia_front/src/components/connections/ConnectionRequestsSection.jsx
@@ -42,7 +42,7 @@ export default function ConnectionRequestsSection() {
       setSelectedRequestId(null);
       // Actualizar el contexto para reflejar el cambio en toda la aplicación
       refreshRequests();
-      setToast({ type: 'info', message: 'Solicitud rechazada.', isVisible: true });
+  setToast({ type: 'rejected', message: 'Solicitud rechazada.', isVisible: true });
     } catch (err) {
       console.error('Error al rechazar solicitud:', err);
       setToast({ type: 'error', message: 'Error al rechazar la solicitud.', isVisible: true });

--- a/conexia_front/src/components/connections/ConnectionRequestsSection.jsx
+++ b/conexia_front/src/components/connections/ConnectionRequestsSection.jsx
@@ -20,10 +20,14 @@ export default function ConnectionRequestsSection() {
 
   const handleAccepted = (id) => {
     setLocalRequests((prev) => prev.filter((req) => req.id !== id));
-    // Mostrar toast inmediato aquí también (redundante por UX snappy)
-    setToast({ type: 'success', message: 'Conexión aceptada.', isVisible: true });
+    // Mostrar toast inmediato solo si no hay flag global (evita duplicados)
     if (typeof window !== 'undefined') {
-      sessionStorage.setItem('connectionAcceptedToast', JSON.stringify({ type: 'success', message: 'Conexión aceptada.', isVisible: true }));
+      const stored = sessionStorage.getItem('connectionAcceptedToast');
+      if (!stored) {
+        setToast({ type: 'success', message: 'Conexión aceptada.', isVisible: true });
+      }
+    } else {
+      setToast({ type: 'success', message: 'Conexión aceptada.', isVisible: true });
     }
   };
   

--- a/conexia_front/src/components/connections/SentRequestsSection.jsx
+++ b/conexia_front/src/components/connections/SentRequestsSection.jsx
@@ -5,6 +5,7 @@ import { getSentConnectionRequests } from '@/service/connections/getSentConnecti
 import { useCancelConnectionRequest } from '@/hooks/connections/useCancelConnectionRequest';
 import SentConnectionRequestCard from '@/components/connections/SentConnectionRequestCard';
 import ConfirmModal from '@/components/ui/ConfirmModal';
+import Toast from '@/components/ui/Toast';
 
 export default function SentRequestsSection() {
   const [requests, setRequests] = useState([]);
@@ -12,6 +13,7 @@ export default function SentRequestsSection() {
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [selectedRequestId, setSelectedRequestId] = useState(null);
+  const [toast, setToast] = useState(null);
   const { cancelRequest, loading: cancelLoading } = useCancelConnectionRequest();
   const router = useRouter();
 
@@ -48,15 +50,17 @@ export default function SentRequestsSection() {
 
   const handleCancel = async () => {
     if (!selectedRequestId) return;
-    
+    // Cerrar modal inmediatamente para una UX consistente
+    setShowModal(false);
+    const requestId = selectedRequestId;
+    setSelectedRequestId(null);
     try {
-      await cancelRequest(selectedRequestId);
-      setRequests(prev => prev.filter(req => req.id !== selectedRequestId));
-      setShowModal(false);
-      setSelectedRequestId(null);
+      await cancelRequest(requestId);
+      setRequests(prev => prev.filter(req => req.id !== requestId));
+      setToast({ type: 'success', message: 'Solicitud cancelada.', isVisible: true });
     } catch (err) {
       console.error('Error al cancelar solicitud:', err);
-      // Opcional: Mostrar mensaje de error
+      setToast({ type: 'error', message: 'Error al cancelar la solicitud.', isVisible: true });
     }
   };
 
@@ -97,6 +101,17 @@ export default function SentRequestsSection() {
         cancelButtonText="Cancelar"
         isLoading={cancelLoading}
       />
+
+      {toast && (
+        <Toast
+          type={toast.type}
+          message={toast.message}
+          isVisible={toast.isVisible}
+          onClose={() => setToast(null)}
+          position="top-center"
+          duration={4000}
+        />
+      )}
     </div>
   );
 }

--- a/conexia_front/src/components/navbar/DropdownUserMenu.jsx
+++ b/conexia_front/src/components/navbar/DropdownUserMenu.jsx
@@ -10,6 +10,7 @@ import { getProfileById } from '@/service/profiles/profilesFetch';
 import { useUserStore } from '@/store/userStore';
 import { ROLES } from '@/constants/roles';
 import { config } from '@/config';
+import { FaRegLightbulb } from 'react-icons/fa';
 
 const defaultAvatar = '/images/default-avatar.png';
 
@@ -141,6 +142,27 @@ export default function DropdownUserMenu({ onLogout, onClose }) {
             >
               <Briefcase size={16} />
               Mis Servicios
+            </Link>
+          </div>
+          <div className="border-t pt-1 mt-1">
+            <div className="px-4 py-1 text-xs font-medium text-gray-500 uppercase tracking-wide">
+              Proyectos
+            </div>
+            <Link
+              href="/project/my-postulations"
+              onClick={handleClose}
+              className="flex items-center gap-2 w-full px-4 py-2 text-sm text-left hover:bg-conexia-green/10"
+            >
+              <FileText size={16} />
+              Mis Postulaciones
+            </Link>
+            <Link
+              href={`/projects/user/${userId}`}
+              onClick={handleClose}
+              className="flex items-center gap-2 w-full px-4 py-2 text-sm text-left hover:bg-conexia-green/10"
+            >
+              <FaRegLightbulb size={16} />
+              Mis Proyectos
             </Link>
           </div>
         </>

--- a/conexia_front/src/components/profile/userProfile/ProfileConnectionButtons.jsx
+++ b/conexia_front/src/components/profile/userProfile/ProfileConnectionButtons.jsx
@@ -562,71 +562,31 @@ export default function ProfileConnectionButtons({ profile, id, isOwner, receive
 
     return (
       <>
-        {/* Mobile: primero Enviar mensaje, luego Aceptar y Rechazar, todos más chicos y alineados */}
+        {/* Mobile: Enviar mensaje con estilo unificado */}
         <div className="flex flex-col items-center justify-center w-full mt-2 sm:hidden gap-2">
           <Button
             variant="primary"
-            className="flex items-center justify-center px-4 py-2 text-sm font-semibold w-56 whitespace-nowrap"
+            className="flex items-center justify-center px-4 h-10 text-sm font-semibold w-56 whitespace-nowrap rounded-full"
             onClick={openChat}
             style={{lineHeight: '1.2'}}
           >
             <Send className="w-4 h-4 mr-2" />
             <span className="truncate">Enviar mensaje</span>
           </Button>
-          <div className="flex gap-2 w-56 justify-center">
+        </div>
+        {/* Desktop: Enviar mensaje agrupado con Aceptar/Rechazar en columna derecha */}
+        <div className="hidden sm:flex absolute right-0 top-1/2 -translate-y-1/2 mr-6 flex-col items-end gap-2">
+          <div className="flex flex-col gap-2 items-end">
             <Button
-              variant="neutral"
-              className="flex items-center justify-center px-4 py-2 text-sm font-semibold w-1/2 whitespace-nowrap"
-              onClick={() => setShowAcceptModal(true)}
-              disabled={acceptLoading}
+              variant="primary"
+              className="flex items-center justify-center px-4 text-sm min-w-[190px] max-w-[190px] h-10 rounded-full"
+              onClick={openChat}
             >
-              <Check className="w-4 h-4 mr-2" />
-              Aceptar
-            </Button>
-            <Button
-              variant="cancel"
-              className="flex items-center justify-center px-4 py-2 text-sm font-semibold w-1/2 whitespace-nowrap"
-              onClick={() => setShowRejectModal(true)}
-              disabled={rejectLoading}
-            >
-              <X className="w-4 h-4 mr-2" />
-              Rechazar
+              <Send className="w-4 h-4 mr-2" />
+              Enviar mensaje
             </Button>
           </div>
         </div>
-
-        <ConfirmModal
-          isOpen={showAcceptModal}
-          onClose={() => setShowAcceptModal(false)}
-          onConfirm={handleAccept}
-          title="Aceptar solicitud"
-          message="¿Estás seguro que deseas aceptar esta solicitud de conexión?"
-          confirmButtonText="Aceptar"
-          cancelButtonText="Cancelar"
-          isLoading={acceptLoading}
-        />
-
-        <ConfirmModal
-          isOpen={showRejectModal}
-          onClose={() => setShowRejectModal(false)}
-          onConfirm={handleReject}
-          title="Rechazar solicitud"
-          message="¿Estás seguro que deseas rechazar esta solicitud de conexión?"
-          confirmButtonText="Rechazar"
-          cancelButtonText="Cancelar"
-          isLoading={rejectLoading}
-        />
-        {toast && (
-          <Toast
-            type={toast.type}
-            message={toast.message}
-            isVisible={toast.isVisible}
-            onClose={() => setToast(null)}
-            position="top-center"
-            duration={4000}
-          />
-        )}
-
       </>
     );
   }

--- a/conexia_front/src/components/profile/userProfile/userProfile.jsx
+++ b/conexia_front/src/components/profile/userProfile/userProfile.jsx
@@ -490,51 +490,47 @@ export default function UserProfile() {
                   })()}
                 </span>
               </div>
-              {/* Botones */}
-              <div className="flex gap-2 w-full sm:w-auto sm:justify-end justify-center">
-                <button
-                  className="flex items-center justify-center bg-conexia-green text-white font-semibold rounded-lg border border-[#e0f0f0] hover:bg-[#285c5c] transition-colors focus:outline-none shadow-sm px-4 py-1 text-sm"
-                  type="button"
-                  onClick={async () => {
-                    setAccepting(true);
-                    await acceptRequest(profile.profile?.connectionData?.id);
-                    // Refrescar el contexto global para actualizar el contador de solicitudes en la navbar
-                    await refreshRequests();
-                    // Refrescar perfil
-                    const data = await getProfileById(id);
-                    setProfile(data.data);
-                    setAccepting(false);
-                    // Toast local inmediato
-                    setToast({ type: 'success', message: 'Conexión aceptada.', isVisible: true });
-                    // Flag para página de conexiones
-                    if (typeof window !== 'undefined') {
-                      sessionStorage.setItem('connectionAcceptedToast', JSON.stringify({ type: 'success', message: 'Conexión aceptada.', isVisible: true }));
-                    }
-                  }}
-                  disabled={acceptLoading || accepting}
-                  style={{ minWidth: 80 }}
-                >
-                  {acceptLoading || accepting ? 'Aceptando...' : 'Aceptar'}
-                </button>
-                <button
-                  className="flex items-center justify-center bg-[#f5f6f6] text-[#777d7d] hover:bg-[#f1f2f2] border border-[#e1e4e4] font-semibold rounded-lg focus:outline-none shadow-sm px-4 py-1 text-sm"
-                  type="button"
-                  onClick={async () => {
-                    setRejecting(true);
-                    await rejectRequest(profile.profile?.connectionData?.id);
-                    // Refrescar el contexto global para actualizar el contador de solicitudes en la navbar
-                    await refreshRequests();
-                    // Refrescar perfil
-                    const data = await getProfileById(id);
-                    setProfile(data.data);
-                    setRejecting(false);
-                    setToast({ type: 'info', message: 'Solicitud rechazada.', isVisible: true });
-                  }}
-                  disabled={rejectLoading || rejecting}
-                  style={{ minWidth: 80 }}
-                >
-                  {rejectLoading || rejecting ? 'Rechazando...' : 'Rechazar'}
-                </button>
+              {/* Botones y Enviar mensaje en desktop */}
+              <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto sm:justify-end justify-center items-center">
+                <div className="flex gap-2">
+                  <button
+                    className="flex items-center justify-center bg-conexia-green text-white font-semibold rounded-lg border border-[#e0f0f0] hover:bg-[#285c5c] transition-colors focus:outline-none shadow-sm px-4 py-1 text-sm"
+                    type="button"
+                    onClick={async () => {
+                      setAccepting(true);
+                      await acceptRequest(profile.profile?.connectionData?.id);
+                      await refreshRequests();
+                      const data = await getProfileById(id);
+                      setProfile(data.data);
+                      setAccepting(false);
+                      setToast({ type: 'success', message: 'Conexión aceptada.', isVisible: true });
+                      if (typeof window !== 'undefined') {
+                        sessionStorage.setItem('connectionAcceptedToast', JSON.stringify({ type: 'success', message: 'Conexión aceptada.', isVisible: true }));
+                      }
+                    }}
+                    disabled={acceptLoading || accepting}
+                    style={{ minWidth: 80 }}
+                  >
+                    {acceptLoading || accepting ? 'Aceptando...' : 'Aceptar'}
+                  </button>
+                  <button
+                    className="flex items-center justify-center bg-[#f5f6f6] text-[#777d7d] hover:bg-[#f1f2f2] border border-[#e1e4e4] font-semibold rounded-lg focus:outline-none shadow-sm px-4 py-1 text-sm"
+                    type="button"
+                    onClick={async () => {
+                      setRejecting(true);
+                      await rejectRequest(profile.profile?.connectionData?.id);
+                      await refreshRequests();
+                      const data = await getProfileById(id);
+                      setProfile(data.data);
+                      setRejecting(false);
+                      setToast({ type: 'rejected', message: 'Solicitud rechazada.', isVisible: true });
+                    }}
+                    disabled={rejectLoading || rejecting}
+                    style={{ minWidth: 80 }}
+                  >
+                    {rejectLoading || rejecting ? 'Rechazando...' : 'Rechazar'}
+                  </button>
+                </div>
               </div>
             </div>
           )}

--- a/conexia_front/src/components/project/detail/ProjectDetail.jsx
+++ b/conexia_front/src/components/project/detail/ProjectDetail.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import Toast from '@/components/ui/Toast';
 import Navbar from '@/components/navbar/Navbar';
 import { MoreVertical } from 'lucide-react';
 import Image from 'next/image';
@@ -27,6 +28,7 @@ export default function ProjectDetail({ projectId }) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [reportLoading, setReportLoading] = useState(false);
+  const [toast, setToast] = useState(null); // Toast para resultado de reporte
   const [menuOpen, setMenuOpen] = useState(false);
   const [messageText, setMessageText] = useState("");
   const [sendingMessage, setSendingMessage] = useState(false);
@@ -486,9 +488,10 @@ ${messageText.trim()}`;
           <ReportProjectModal
             onCancel={() => setShowReportModal(false)}
             loading={reportLoading}
-            onSubmit={async (data, setMsg) => {
+            onSubmit={async (data) => {
               setReportLoading(true);
-              setMsg(null);
+              // Cerrar modal inmediatamente
+              setShowReportModal(false);
               try {
                 await createProjectReport({
                   projectId: Number(projectId),
@@ -496,19 +499,20 @@ ${messageText.trim()}`;
                   otherReason: data.other,
                   description: data.description,
                 });
-                setMsg({ ok: true, text: 'Proyecto reportado con éxito.' });
-                setTimeout(() => setShowReportModal(false), 1500);
+                setToast({ type: 'success', message: 'Proyecto reportado con éxito.', isVisible: true });
+                setAlreadyReported(true);
               } catch (err) {
-                // Interceptar mensaje exacto del backend
                 const alreadyReportedRegex = /Project with id \d+ has already been reported by user \d+/;
-                if (
+                const conflict = (
                   (err.message && err.message.toLowerCase().includes('conflict')) ||
                   (err.message && alreadyReportedRegex.test(err.message))
-                ) {
-                  setMsg({ ok: false, text: 'Ya has reportado este proyecto.' });
-                  setTimeout(() => setShowReportModal(false), 1500);
+                );
+                if (conflict) {
+                  setToast({ type: 'warning', message: 'Ya has reportado este proyecto.', isVisible: true });
+                  setAlreadyReported(true);
                 } else {
-                  setMsg({ ok: false, text: err.message || 'Error al reportar el proyecto' });
+                  console.error('Error al reportar proyecto:', err);
+                  setToast({ type: 'error', message: 'Error al reportar el proyecto. Inténtalo más tarde.', isVisible: true });
                 }
               } finally {
                 setReportLoading(false);
@@ -522,6 +526,16 @@ ${messageText.trim()}`;
       <MessagingWidget
         avatar={avatar}
       />
+      {toast && (
+        <Toast
+          type={toast.type}
+          message={toast.message}
+          isVisible={toast.isVisible}
+          onClose={() => setToast(null)}
+          position="top-center"
+          duration={4000}
+        />
+      )}
     </>
   );
 }

--- a/conexia_front/src/components/project/postulation/PostulationButton.jsx
+++ b/conexia_front/src/components/project/postulation/PostulationButton.jsx
@@ -17,7 +17,7 @@ export default function PostulationButton({
   className = '' 
 }) {
   const [showModal, setShowModal] = useState(false);
-  const [showSuccess, setShowSuccess] = useState(false);
+  const [toast, setToast] = useState({ visible: false, type: 'success', message: '' });
   const [showCancelConfirm, setShowCancelConfirm] = useState(false);
   
   const {
@@ -44,8 +44,7 @@ export default function PostulationButton({
     const success = await handleApply(cvFile, project);
     if (success) {
       setShowModal(false);
-      setShowSuccess(true);
-      setTimeout(() => setShowSuccess(false), 5000); // Ocultar después de 5 segundos
+      setToast({ visible: true, type: 'success', message: 'Postulación enviada correctamente.' });
     }
   };
 
@@ -53,6 +52,7 @@ export default function PostulationButton({
     const success = await handleCancel();
     if (success) {
       setShowCancelConfirm(false);
+      setToast({ visible: true, type: 'success', message: 'Postulación cancelada correctamente.' });
     }
   };
 
@@ -194,23 +194,25 @@ export default function PostulationButton({
                   {error}
                 </div>
               )}
-              <div className="flex flex-row space-x-3">
+              <div className="flex flex-wrap justify-end gap-3 pt-2">
                 <button
                   onClick={() => {
                     setShowCancelConfirm(false);
                     setError(null);
                   }}
                   disabled={loading}
-                  className="flex-1 bg-[#f5f6f6] text-[#777d7d] px-4 py-2 rounded font-medium hover:bg-[#f1f2f2] transition border border-[#e1e4e4]"
+                  className="bg-[#f5f6f6] text-[#555] px-5 py-2 rounded-lg font-medium hover:bg-[#eceeee] transition border border-[#d9dddd] shadow-sm focus:outline-none focus:ring-2 focus:ring-conexia-green/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                  aria-label="Volver sin cancelar la postulación"
                 >
                   Volver
                 </button>
                 <button
                   onClick={onCancelSuccess}
                   disabled={loading}
-                  className="flex-1 bg-red-600 text-white px-4 py-2 rounded font-medium hover:bg-red-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="bg-red-600 text-white px-5 py-2 rounded-lg font-semibold hover:bg-red-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-red-400/40 transition disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                  aria-label="Confirmar cancelación de la postulación"
                 >
-                  {loading ? 'Cancelando...' : 'Cancelar postulación'}
+                  {loading ? 'Cancelando…' : 'Cancelar postulación'}
                 </button>
               </div>
             </div>
@@ -218,13 +220,14 @@ export default function PostulationButton({
         </div>
       )}
 
-      {/* Toast de éxito */}
+      {/* Toast de postulación/cancelación */}
       <Toast
-        type="success"
-        message="Tu postulación fue enviada correctamente."
-        isVisible={showSuccess}
-        onClose={() => setShowSuccess(false)}
+        type={toast.type}
+        message={toast.message}
+        isVisible={toast.visible}
+        onClose={() => setToast(t => ({ ...t, visible: false }))}
         duration={5000}
+        position="top-center"
       />
     </>
   );

--- a/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
+++ b/conexia_front/src/components/project/postulations/PostulationEvaluationModal.jsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { approvePostulation, rejectPostulation } from '@/service/postulations/postulationService';
 import { config } from '@/config';
 
-export default function PostulationEvaluationModal({ postulation, onClose, onApproved }) {
+export default function PostulationEvaluationModal({ postulation, onClose, onApproved, onResult }) {
   const [isApproving, setIsApproving] = useState(false);
   const [isRejecting, setIsRejecting] = useState(false);
   const [error, setError] = useState('');
@@ -16,19 +16,19 @@ export default function PostulationEvaluationModal({ postulation, onClose, onApp
     try {
       setIsApproving(true);
       setError('');
-      
       await approvePostulation(postulation.id);
-      
-      setSuccess('Postulación aprobada correctamente');
-      
-      // Mostrar mensaje de éxito por un momento antes de cerrar
-      setTimeout(() => {
+      const message = 'Postulación aprobada correctamente';
+      setSuccess(message);
+      if (onResult) {
+        onResult({ status: 'approved', message });
+      } else if (onApproved) {
         onApproved();
-      }, 1500);
-      
-    } catch (error) {
-      console.error('Error approving postulation:', error);
-      setError(error.message || 'Error al aprobar la postulación');
+      }
+    } catch (err) {
+      console.error('Error approving postulation:', err);
+      const errMsg = err.message || 'Error al aprobar la postulación';
+      setError(errMsg);
+      if (onResult) onResult({ status: 'error', message: errMsg });
     } finally {
       setIsApproving(false);
     }
@@ -42,12 +42,13 @@ export default function PostulationEvaluationModal({ postulation, onClose, onApp
       await rejectPostulation(postulation.id);
       
       setSuccess('Postulación rechazada correctamente');
-      
-      // Mostrar mensaje de éxito por un momento antes de cerrar
-      setTimeout(() => {
-        onApproved(); // Same callback to refresh the list
-      }, 1500);
-      
+      const message = 'Postulación rechazada correctamente';
+      setSuccess(message);
+      if (onResult) {
+        onResult({ status: 'rejected', message });
+      } else if (onApproved) {
+        onApproved();
+      }
     } catch (error) {
       console.error('Error rejecting postulation:', error);
       setError(error.message || 'Error al rechazar la postulación');
@@ -185,7 +186,7 @@ export default function PostulationEvaluationModal({ postulation, onClose, onApp
             className="flex-1 bg-gray-300 text-gray-700 px-4 py-2 rounded font-medium hover:bg-gray-400 transition"
             disabled={isApproving || isRejecting}
           >
-            Volver
+            Cancelar
           </button>
           
           <button

--- a/conexia_front/src/components/project/postulations/ProjectPostulations.jsx
+++ b/conexia_front/src/components/project/postulations/ProjectPostulations.jsx
@@ -10,6 +10,7 @@ import { getProfileById } from '@/service/profiles/profilesFetch';
 import { fetchProjectById } from '@/service/projects/projectsFetch';
 import PostulationsTable from './PostulationsTable';
 import PostulationEvaluationModal from './PostulationEvaluationModal';
+import Toast from '@/components/ui/Toast';
 import Pagination from '@/components/common/Pagination';
 
 export default function ProjectPostulations({ projectId }) {
@@ -25,6 +26,7 @@ export default function ProjectPostulations({ projectId }) {
   const [showEvaluationModal, setShowEvaluationModal] = useState(false);
   const [selectedPostulation, setSelectedPostulation] = useState(null);
   const [loadingProfiles, setLoadingProfiles] = useState(false);
+  const [toast, setToast] = useState({ isVisible: false, type: 'info', message: '' });
 
   // Verificar si el usuario es dueño del proyecto
   const isOwner = user && project && (String(user.id) === String(project.ownerId) || project.isOwner);
@@ -151,6 +153,20 @@ export default function ProjectPostulations({ projectId }) {
     loadPostulations();
   };
 
+  const handleEvaluationResult = (result) => {
+    // result: { status: 'approved' | 'rejected', message }
+    setShowEvaluationModal(false);
+    setSelectedPostulation(null);
+    if (result?.status === 'approved') {
+      setToast({ isVisible: true, type: 'success', message: result.message || 'Postulación aprobada correctamente.' });
+    } else if (result?.status === 'rejected') {
+      setToast({ isVisible: true, type: 'rejected', message: result.message || 'Postulación rechazada.' });
+    } else if (result?.status === 'error') {
+      setToast({ isVisible: true, type: 'error', message: result.message || 'Error al evaluar la postulación.' });
+    }
+    loadPostulations();
+  };
+
   const handleStatusChange = (statusId) => {
     setSelectedStatus(statusId);
     setCurrentPage(1); // Reset to first page when changing filter
@@ -194,18 +210,19 @@ export default function ProjectPostulations({ projectId }) {
             {/* Filtro por estado */}
             <div className="flex items-center gap-2">
               <label className="text-sm font-medium text-gray-700">Filtrar por estado:</label>
-              <select
-                value={selectedStatus}
-                onChange={(e) => handleStatusChange(e.target.value)}
-                className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-conexia-green"
-              >
-                <option value="">Todos los estados</option>
-                {postulationStatuses.map((status) => (
-                  <option key={status.id} value={status.id}>
-                    {status.name}
-                  </option>
-                ))}
-              </select>
+                <select
+                  value={selectedStatus}
+                  onChange={(e) => handleStatusChange(e.target.value)}
+                  className="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-conexia-green"
+                >
+                                 
+                  <option value="">Todos los estados</option>
+                  {postulationStatuses.map((status) => (
+                    <option key={status.id} value={status.id}>
+                      {status.name}
+                    </option>
+                  ))}
+                </select>
             </div>
           </div>
 
@@ -261,9 +278,17 @@ export default function ProjectPostulations({ projectId }) {
         <PostulationEvaluationModal
           postulation={selectedPostulation}
           onClose={() => setShowEvaluationModal(false)}
-          onApproved={handlePostulationApproved}
+          onResult={handleEvaluationResult}
         />
       )}
+
+      <Toast
+        position="top-center"
+        type={toast.type}
+        message={toast.message}
+        isVisible={toast.isVisible}
+        onClose={() => setToast(t => ({ ...t, isVisible: false }))}
+      />
     </>
   );
 }

--- a/conexia_front/src/components/project/report/ReportProjectModal.jsx
+++ b/conexia_front/src/components/project/report/ReportProjectModal.jsx
@@ -16,7 +16,6 @@ export default function ReportProjectModal({ onCancel, onSubmit, loading }) {
   const [otherText, setOtherText] = useState("");
   const [description, setDescription] = useState("");
   const [error, setError] = useState("");
-  const [msg, setMsg] = useState(null);
   const handleReasonChange = (reason) => {
     setSelectedReason(reason);
     if (reason !== "Otro") {
@@ -25,17 +24,14 @@ export default function ReportProjectModal({ onCancel, onSubmit, loading }) {
   };
   const handleSubmit = () => {
     setError("");
-    setMsg(null);
     if (!selectedReason) {
       setError("Debes seleccionar un motivo.");
       return;
     }
-    // Validación para 'Otro'
     if (selectedReason === "Otro" && !otherText.trim()) {
       setError("Debes completar el campo 'Otro'.");
       return;
     }
-    // No permitir enviar otherReason si el motivo no es 'Otro'
     if (selectedReason !== "Otro" && otherText.trim()) {
       setError("No debes completar el campo 'Otro' si el motivo no es 'Otro'.");
       return;
@@ -48,7 +44,7 @@ export default function ReportProjectModal({ onCancel, onSubmit, loading }) {
       reason: selectedReason,
       other: selectedReason === "Otro" ? otherText : undefined,
       description,
-    }, setMsg);
+    });
   };
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-40 flex justify-center items-center overflow-auto">
@@ -119,11 +115,9 @@ export default function ReportProjectModal({ onCancel, onSubmit, loading }) {
             maxLength={500}
           />
         </div>
-  <div className="min-h-[24px] text-center text-sm transition-all duration-300 mb-1">
+        <div className="min-h-[24px] text-center text-sm transition-all duration-300 mb-1">
           {error && <p className="text-red-600">{error}</p>}
-          {msg && (
-            <p className={msg.ok ? 'text-green-600' : 'text-red-600'}>{msg.text}</p>
-          )}
+          {/* Mensajes de resultado ahora se manejan con Toast externo */}
         </div>
         <style jsx>{`
           div[class*='max-h-[95vh]']::-webkit-scrollbar {

--- a/conexia_front/src/components/services/ServiceSearch.jsx
+++ b/conexia_front/src/components/services/ServiceSearch.jsx
@@ -123,18 +123,8 @@ export default function ServiceSearch() {
               </div>
             </div>
             <div className="flex flex-col sm:flex-row gap-2 justify-center md:justify-end w-full md:w-auto mt-4 md:mt-0">
-              {canViewHirings && (
-                <button 
-                  onClick={() => router.push('/services/my-hirings')}
-                  className="bg-blue-600 text-white font-semibold rounded-lg px-4 py-3 shadow hover:bg-blue-700 transition text-sm whitespace-nowrap flex items-center justify-center gap-2 w-full sm:w-auto"
-                >
-                  <FileText size={16} />
-                  <span>Mis Solicitudes</span>
-                </button>
-              )}
-              
               {canCreateService && (
-                <Link href="/services/create" className="w-full sm:w-auto">
+                <Link href="/services/create" className="w-full sm:w-auto order-1 sm:order-none">
                   <button className="bg-conexia-green text-white font-semibold rounded-lg px-4 py-3 shadow hover:bg-conexia-green/90 transition text-sm whitespace-nowrap flex items-center justify-center gap-2 w-full">
                     <span className="flex items-center justify-center gap-2 w-full">
                       <Briefcase size={16} className="text-base" />
@@ -142,6 +132,15 @@ export default function ServiceSearch() {
                     </span>
                   </button>
                 </Link>
+              )}
+              {canViewHirings && (
+                <button 
+                  onClick={() => router.push('/services/my-hirings')}
+                  className="bg-[#367d7d] text-white font-semibold rounded-lg px-4 py-3 shadow hover:bg-[#2b6a6a] transition text-sm whitespace-nowrap flex items-center justify-center gap-2 w-full sm:w-auto order-2 sm:order-none"
+                >
+                  <FileText size={16} />
+                  <span>Mis Solicitudes</span>
+                </button>
               )}
             </div>
           </div>

--- a/conexia_front/src/components/settings/sections/SecuritySection.jsx
+++ b/conexia_front/src/components/settings/sections/SecuritySection.jsx
@@ -1,15 +1,32 @@
-'use client';
-
+"use client";
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 import SettingCard from '../shared/SettingCard';
+import Toast from '@/components/ui/Toast';
 
 export default function SecuritySection() {
   const router = useRouter();
+  const [toast, setToast] = useState({ visible: false, type: 'success', message: '' });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = sessionStorage.getItem('passwordChangeToast');
+      if (stored) {
+        try {
+          const data = JSON.parse(stored);
+          setToast({ visible: true, type: data.type || 'success', message: data.message || 'Operación realizada.' });
+        } catch {
+          // ignore
+        } finally {
+          sessionStorage.removeItem('passwordChangeToast');
+        }
+      }
+    }
+  }, []);
 
   return (
-    <div>
+    <div className="relative">
       <h2 className="text-2xl font-bold text-conexia-green mb-6">Seguridad</h2>
-
       <div className="border rounded-lg divide-y overflow-hidden bg-white shadow-sm">
         <SettingCard
           title="Cambiar contraseña"
@@ -18,6 +35,14 @@ export default function SecuritySection() {
           onClick={() => router.push('/settings/security/change-password')}
         />
       </div>
+      <Toast
+        type={toast.type}
+        message={toast.message}
+        isVisible={toast.visible}
+        onClose={() => setToast(t => ({ ...t, visible: false }))}
+        position="top-center"
+        duration={5000}
+      />
     </div>
   );
 }

--- a/conexia_front/src/components/ui/ExistingMediaPreview.jsx
+++ b/conexia_front/src/components/ui/ExistingMediaPreview.jsx
@@ -1,22 +1,24 @@
 "use client";
+import { config } from '@/config';
+
+// Export helper to reuse in modals
+export const buildExistingMediaUrl = (mediaUrl) => {
+  if (!mediaUrl) return '';
+  if (mediaUrl.startsWith('http://') || mediaUrl.startsWith('https://')) return mediaUrl;
+  const base = config?.IMAGE_URL || '';
+  if (mediaUrl.startsWith('/uploads')) {
+    const pathWithoutUploads = mediaUrl.replace('/uploads', '');
+    return `${base}/uploads${pathWithoutUploads}`;
+  }
+  if (mediaUrl.startsWith('/')) return `${base}/uploads${mediaUrl}`;
+  return `${base}/uploads/${mediaUrl}`;
+};
 
 export default function ExistingMediaPreview({ media, removedIds, onToggleRemove }) {
   if (!media || media.length === 0) return null;
 
   // Función para construir URL de medios (similar a getMediaUrl)
-  const getMediaUrl = (mediaUrl) => {
-    if (!mediaUrl) return '';
-    if (mediaUrl.startsWith('http://') || mediaUrl.startsWith('https://')) return mediaUrl;
-    
-    // Si la URL del backend viene con /uploads, construir URL completa
-    if (mediaUrl.startsWith('/uploads')) {
-      const pathWithoutUploads = mediaUrl.replace('/uploads', '');
-      return `http://localhost:8080/uploads${pathWithoutUploads}`;
-    }
-    
-    if (mediaUrl.startsWith('/')) return `http://localhost:8080/uploads${mediaUrl}`;
-    return `http://localhost:8080/uploads/${mediaUrl}`;
-  };
+  const getMediaUrl = buildExistingMediaUrl;
 
   return (
     <div className="existing-media-preview">

--- a/conexia_front/src/components/ui/MediaPreview.jsx
+++ b/conexia_front/src/components/ui/MediaPreview.jsx
@@ -1,27 +1,27 @@
 "use client";
 import { useState } from 'react';
 
-export default function MediaPreview({ files, onRemove, maxFiles = 5 }) {
+export default function MediaPreview({ files, onRemove, maxFiles = 5, onSelect }) {
   if (!files || files.length === 0) return null;
 
   return (
     <div className="media-preview-grid">
       {files.map((file, index) => (
-        <div key={index} className="media-preview-item">
+        <div key={index} className="media-preview-item" onClick={() => onSelect && onSelect(index)}>
           {file.type.startsWith('image/') ? (
-            <img 
+            <img
               src={URL.createObjectURL(file)}
               alt={`Preview ${index + 1}`}
-              className="preview-media"
+              className="preview-media clickable"
             />
           ) : file.type.startsWith('video/') ? (
-            <video 
+            <video
               src={URL.createObjectURL(file)}
-              className="preview-media"
+              className="preview-media clickable"
               muted
             />
           ) : (
-            <div className="preview-placeholder">
+            <div className="preview-placeholder clickable">
               <span>Archivo</span>
             </div>
           )}
@@ -40,24 +40,25 @@ export default function MediaPreview({ files, onRemove, maxFiles = 5 }) {
       <style jsx>{`
         .media-preview-grid {
           display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
-          gap: 8px;
+          grid-template-columns: repeat(2, 1fr);
+          gap: 12px;
           margin-top: 8px;
-          padding: 0 4px;
+          padding: 0 4px 4px 4px;
           max-width: 100%;
-          overflow: hidden;
         }
 
         .media-preview-item {
           position: relative;
-          aspect-ratio: 1;
-          border-radius: 6px;
+          border-radius: 10px;
           overflow: hidden;
           border: 2px solid #e0f0f0;
           background: #f8fcfc;
-          max-width: 100px;
-          max-height: 100px;
+          width: 100%;
+          height: 180px; /* Larger preview height */
+          cursor: pointer;
+          transition: transform 0.15s ease;
         }
+        .media-preview-item:hover { transform: scale(1.01); }
 
         .preview-media {
           width: 100%;
@@ -107,6 +108,10 @@ export default function MediaPreview({ files, onRemove, maxFiles = 5 }) {
           padding: 1px 4px;
           border-radius: 8px;
           font-size: 8px;
+        }
+
+        @media (max-width: 640px) {
+          .media-preview-item { height: 150px; }
         }
       `}</style>
     </div>

--- a/conexia_front/src/components/ui/Toast.jsx
+++ b/conexia_front/src/components/ui/Toast.jsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { CheckCircle, AlertCircle, X, Info, AlertTriangle } from 'lucide-react';
+import { CheckCircle, AlertCircle, X, Info, AlertTriangle, XCircle } from 'lucide-react';
 
 export default function Toast({ 
   type = 'info', 
@@ -36,6 +36,8 @@ export default function Toast({
         return <CheckCircle size={20} />;
       case 'error':
         return <AlertCircle size={20} />;
+      case 'rejected':
+        return <XCircle size={20} />;
       case 'warning':
         return <AlertTriangle size={20} />;
       case 'info':
@@ -49,6 +51,8 @@ export default function Toast({
       case 'success':
         return 'bg-green-500 text-white';
       case 'error':
+        return 'bg-red-600 text-white';
+      case 'rejected':
         return 'bg-red-500 text-white';
       case 'warning':
         return 'bg-yellow-500 text-white';

--- a/conexia_front/src/utils/mediaUrl.js
+++ b/conexia_front/src/utils/mediaUrl.js
@@ -1,0 +1,60 @@
+// Utilidad central para construir URLs de medios (imágenes / videos)
+// Normaliza variaciones: fileUrl, mediaUrl, file_path, fileName
+import { config } from '@/config';
+
+// Construye una URL válida para un medio evitando duplicar /uploads
+// Casos soportados:
+//  - raw ya es URL absoluta -> se retorna igual
+//  - raw comienza con /uploads/...
+//  - raw comienza con uploads/...
+//  - raw comienza con /... (sin uploads)
+//  - raw es solo un nombre/segmento
+export function buildMediaUrl(raw) {
+  if (!raw) return '';
+  let mediaUrl = String(raw);
+  if (mediaUrl.startsWith('http://') || mediaUrl.startsWith('https://')) return mediaUrl;
+
+  let base = config?.IMAGE_URL || '';
+  // Normalizar base removiendo slash final
+  base = base.replace(/\/$/, '');
+
+  // Asegurar que la base termina en /uploads (este backend expone archivos ahí)
+  if (!/\/uploads$/.test(base)) {
+    base = base + '/uploads';
+  }
+
+  // Normalizar mediaUrl para evitar duplicados
+  // Reemplazar ocurrencias dobles /uploads/uploads -> /uploads
+  mediaUrl = mediaUrl.replace(/\/uploads\/uploads/g, '/uploads');
+
+  // Quitar prefijo 'uploads/' si viene sin slash inicial
+  if (mediaUrl.startsWith('uploads/')) {
+    mediaUrl = mediaUrl.substring('uploads/'.length);
+  }
+
+  // Si inicia con /uploads ya tenemos el prefijo: quitamos solo la primera aparición para concatenar
+  if (mediaUrl.startsWith('/uploads')) {
+    mediaUrl = mediaUrl.replace('/uploads', ''); // queda /resto o vacío
+  }
+
+  // Si llega como ruta absoluta que no contiene uploads (empieza con /) la anexamos detrás de /uploads
+  if (mediaUrl.startsWith('/') && !mediaUrl.startsWith('/')) {
+    // (caso imposible por la condición, se deja por claridad)
+  }
+
+  // Asegurar que mediaUrl empieza con '/'
+  if (!mediaUrl.startsWith('/')) mediaUrl = '/' + mediaUrl;
+
+  return base + mediaUrl;
+}
+
+// Extrae la URL efectiva desde un objeto de media con diferentes keys
+export function extractMediaPath(mediaObj) {
+  if (!mediaObj || typeof mediaObj !== 'object') return '';
+  return mediaObj.fileUrl || mediaObj.mediaUrl || mediaObj.file_path || mediaObj.file || mediaObj.fileName || '';
+}
+
+// Helper completo: pasa objeto media y construye URL final
+export function getMediaUrlFromObject(mediaObj) {
+  return buildMediaUrl(extractMediaPath(mediaObj));
+}


### PR DESCRIPTION
Unificar y mejorar la experiencia de usuario en acciones clave (creación, edición, eliminación, reportes, evaluaciones y gestión de relaciones) mediante un sistema consistente de notificaciones TOAST, reemplazando mensajes ambiguos o ausentes dentro de modales. Además, mejorar la visualización y exploración de archivos multimedia adjuntos en publicaciones, y enriquecer el menú desplegable del usuario con accesos rápidos a sus proyectos y postulaciones.

Resumen de mejoras principales

1. Sistema unificado de notificaciones TOAST para todas las acciones críticas (éxito / error / rechazo).
2. Variante específica de toast para rechazos (rejected) con color rojo diferenciado de [error](vscode-file://vscode-app/c:/Users/alexp/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
3. Eliminación de mensajes internos redundantes en modales (se centraliza el feedback visual).
4. Visualización mejorada de imágenes, GIFs y videos al crear/editar publicaciones (thumbnails más grandes + modal visor con carrusel).
5. Propagación de feedback entre páginas mediante flags en [sessionStorage](vscode-file://vscode-app/c:/Users/alexp/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (por ejemplo, aceptación de conexión y actualización de perfil).
6. Nueva sección “Proyectos” en el dropdown del usuario: accesos a “Mis Postulaciones” y “Mis Proyectos”.
7. Ajustes de consistencia visual en botones y selectores (reorden de botones en Servicios, normalización de colores, mejora en select “Filtrar por estado” en postulaciones).
8. Evaluación de postulaciones (Aprobar / Rechazar) ahora con toasts inmediatos.
9. Inclusión de feedback en gestión de usuarios internos (crear, editar, eliminar).
10. Reordenamiento y unificación de semántica en flujos de conexión (aceptar, rechazar, cancelar, eliminar).

Alcance detallado por área
Publicaciones
  - Toast al crear, editar y eliminar publicaciones.
  - Toast al reportar publicaciones.
  - Vista previa mejorada de adjuntos: imágenes / GIF / videos más grandes antes de publicar.
  - Modal visor/carrusel para recorrer los adjuntos (también disponible al editar).
  
Proyectos
  - Toast al crear y eliminar proyectos.
  - Toast al postularse y al cancelar/eliminar una postulación.
  - Toast al reportar un proyecto.
  - Evaluación de postulaciones (Aprobar/Rechazar) ahora dispara toasts inmediatos (éxito o error).
  - Botón “Mis postulaciones” estilizado (color consistente con identidad secundaria).
  - Select de “Filtrar por estado” refinado (alineación y caret personalizado).

Postulaciones (evaluación)
  - Refactor del modal: se eliminó lógica redundante de mensajes internos.
  - Callback [onResult](vscode-file://vscode-app/c:/Users/alexp/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) unifica estados: approved, rejected, [error](vscode-file://vscode-app/c:/Users/alexp/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
  - Uso de variante visual rejected para rechazos (rojo suave, distinto de error).

Perfil / Usuario
  - Toast inmediato al editar perfil (sin necesidad de refrescar manual).
  - Prevención de fugas de toasts entre perfiles con clave profileUpdateToast:<userId>.
  - Cambio de contraseña con feedback consistente.

Conexiones
  - Toast al enviar, cancelar o rechazar solicitudes.
  - Toast al aceptar conexión (propagado entre páginas usando [sessionStorage](vscode-file://vscode-app/c:/Users/alexp/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → connectionAcceptedToast).
  - Unificación de feedback al eliminar una conexión ya establecida.
  - Variante rejected en rechazo de solicitudes (ya no se usa warning ni info para rechazos).

Usuarios Internos (Administración)
  - Crear / Editar / Eliminar usuarios internos migrado de mensajes inline a toasts globales.
  - Limpieza de estados internos y temporizadores redundantes.

Navegación / Menú de Usuario
  - Sección nueva “Proyectos” en el dropdown:
  - “Mis Postulaciones” → /project/my-postulations
  - “Mis Proyectos” → /projects/user/{idUsuario}
  - Se mantiene “Servicios” con accesos previos.
  - Reordenamiento de botones en Servicios: “Publica tu servicio” a la izquierda y “Mis Solicitudes” a la derecha, con color de énfasis coherente con “Mis postulaciones”.

